### PR TITLE
Fix/firewall zone policy bugs

### DIFF
--- a/internal/provider/firewall/resource_firewall_zone_policy.go
+++ b/internal/provider/firewall/resource_firewall_zone_policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/utils"
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -19,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -635,13 +633,9 @@ func (r *firewallZonePolicyResource) Schema(ctx context.Context, _ resource.Sche
 				Default:             booldefault.StaticBool(false),
 			},
 			"index": schema.Int64Attribute{
-				MarkdownDescription: "Priority index for the policy.",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(10000),
-				Validators: []validator.Int64{
-					int64validator.AtLeast(0),
-				},
+				MarkdownDescription: "Priority index for the policy. This value is assigned by the UniFi controller and cannot be set directly. " +
+					"To control policy ordering, use the `unifi_firewall_zone_policy_order` resource (planned for future release).",
+				Computed: true,
 			},
 			"logging": schema.BoolAttribute{
 				MarkdownDescription: "Enable to generate syslog entries when traffic is matched.",

--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -724,7 +724,12 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("purpose", resp.Purpose)
 	d.Set("vlan_id", vlan)
 	d.Set("subnet", utils.CidrZeroBased(resp.IPSubnet))
-	d.Set("network_group", resp.NetworkGroup)
+
+	networkGroup := resp.NetworkGroup
+	if resp.Purpose == "wan" && networkGroup == "" {
+		networkGroup = "LAN"
+	}
+	d.Set("network_group", networkGroup)
 
 	d.Set("dhcp_dns", dhcpDNS)
 	d.Set("dhcp_enabled", resp.DHCPDEnabled)
@@ -746,7 +751,12 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("igmp_snooping", resp.IGMPSnooping)
 	d.Set("internet_access_enabled", resp.InternetAccessEnabled)
 	d.Set("network_isolation_enabled", resp.NetworkIsolationEnabled)
-	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)
+
+	ipv6InterfaceType := resp.IPV6InterfaceType
+	if resp.Purpose == "wan" && ipv6InterfaceType == "" {
+		ipv6InterfaceType = "none"
+	}
+	d.Set("ipv6_interface_type", ipv6InterfaceType)
 	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
 	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)
 	d.Set("ipv6_pd_start", resp.IPV6PDStart)

--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -736,7 +736,12 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("purpose", resp.Purpose)
 	d.Set("vlan_id", vlan)
 	d.Set("subnet", utils.CidrZeroBased(resp.IPSubnet))
-	d.Set("network_group", resp.NetworkGroup)
+
+	networkGroup := resp.NetworkGroup
+	if resp.Purpose == "wan" && networkGroup == "" {
+		networkGroup = "LAN"
+	}
+	d.Set("network_group", networkGroup)
 
 	d.Set("dhcp_dns", dhcpDNS)
 	d.Set("dhcp_enabled", resp.DHCPDEnabled)
@@ -759,7 +764,12 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("upnp_lan_enabled", resp.UpnpLanEnabled)
 	d.Set("internet_access_enabled", resp.InternetAccessEnabled)
 	d.Set("network_isolation_enabled", resp.NetworkIsolationEnabled)
-	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)
+
+	ipv6InterfaceType := resp.IPV6InterfaceType
+	if resp.Purpose == "wan" && ipv6InterfaceType == "" {
+		ipv6InterfaceType = "none"
+	}
+	d.Set("ipv6_interface_type", ipv6InterfaceType)
 	d.Set("ipv6_pd_interface", resp.IPV6PDInterface)
 	d.Set("ipv6_pd_prefixid", resp.IPV6PDPrefixid)
 	d.Set("ipv6_pd_start", resp.IPV6PDStart)


### PR DESCRIPTION
## Summary

Fixes two bugs affecting `unifi_firewall_zone_policy` and `unifi_network` resources.

## Bug Fixes

#### 1. `index` field causes "Provider produced inconsistent result after apply" in `unifi_firewall_zone_policy`

The UniFi API ignores the `index` value on create/update and assigns its own value based on policy creation order. Since Terraform expects the resulting state to match the planned state, this causes:

```
│ Error: Provider produced inconsistent result after apply
│
│ .index: was cty.NumberIntVal(10001), but now cty.NumberIntVal(10003).
```

**Fix:** Changed `index` from `Optional`+`Computed` with a default to `Computed`-only. The field is now read-only, preventing users from setting a value that will be ignored.

> **Note:** Policy ordering is controlled via a separate `batch-reorder` API endpoint. A future `unifi_firewall_zone_policy_order` resource could be added to support this.

#### 2. Perpetual drift for `network_group` and `ipv6_interface_type` in WAN `unifi_network`

For WAN networks, the API returns empty strings for `network_group` and `ipv6_interface_type`. Since these fields have schema defaults (`"LAN"` and `"none"`), Terraform sees a diff between config (default) and state (empty), causing perpetual drift:

```
~ resource "unifi_network" "wan1" {
  + ipv6_interface_type = "none"
  + network_group       = "LAN"
  }
```

**Fix:** When reading WAN networks, if the API returns empty values for these fields, explicitly set them to their schema defaults.

## Test Plan

- [x] Tested `unifi_firewall_zone_policy` create/update no longer fails with index error
- [x] Tested `unifi_network` with `purpose = "wan"` no longer shows perpetual drift
