### PR TITLE
feat: add IPv6 network types (ADDRv6, NETv6) to firewall rule validation

### DIFF
--- a/internal/provider/firewall/resource_firewall_rule.go
+++ b/internal/provider/firewall/resource_firewall_rule.go
@@ -147,11 +147,13 @@ func ResourceFirewallRule() *schema.Resource {
 			"src_network_type": {
 				Description: "The type of source network address. Valid values are:\n" +
 					"  * `ADDRv4` - Single IPv4 address\n" +
-					"  * `NETv4` - IPv4 network in CIDR notation",
+					"  * `NETv4` - IPv4 network in CIDR notation\n" +
+					"  * `ADDRv6` - Single IPv6 address\n" +
+					"  * `NETv6` - IPv6 network in CIDR notation",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "NETv4",
-				ValidateFunc: validation.StringInSlice([]string{"ADDRv4", "NETv4"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"ADDRv4", "NETv4", "ADDRv6", "NETv6"}, false),
 			},
 			"src_firewall_group_ids": {
 				Description: "A list of firewall group IDs to use as sources. Groups can contain:\n" +
@@ -203,11 +205,13 @@ func ResourceFirewallRule() *schema.Resource {
 			"dst_network_type": {
 				Description: "The type of destination network address. Valid values are:\n" +
 					"  * `ADDRv4` - Single IPv4 address\n" +
-					"  * `NETv4` - IPv4 network in CIDR notation",
+					"  * `NETv4` - IPv4 network in CIDR notation\n" +
+					"  * `ADDRv6` - Single IPv6 address\n" +
+					"  * `NETv6` - IPv6 network in CIDR notation",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "NETv4",
-				ValidateFunc: validation.StringInSlice([]string{"ADDRv4", "NETv4"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"ADDRv4", "NETv4", "ADDRv6", "NETv6"}, false),
 			},
 			"dst_firewall_group_ids": {
 				Description: "A list of firewall group IDs to use as destinations. Groups can contain IP addresses, networks, or port numbers. " +


### PR DESCRIPTION
## Summary

The UniFi API accepts `ADDRv6` and `NETv6` as valid values for `src_network_type` and `dst_network_type` on firewall rules. These are needed when creating IPv6 firewall rules (e.g., rules in the `LANv6_IN` ruleset that reference a network), but the provider's `ValidateFunc` only allows `ADDRv4` and `NETv4`, causing plan-time validation errors for valid configurations.

This PR:
- Adds `ADDRv6` and `NETv6` to the `ValidateFunc` allowed values for both `src_network_type` and `dst_network_type`
- Updates the `Description` strings for both fields to document the new values

## Context

When managing IPv6 firewall rules via OpenTofu/Terraform, rules that use `src_network_type = "NETv6"` or `dst_network_type = "NETv6"` fail at plan time with:

```
expected src_network_type to be one of ["ADDRv4" "NETv4"], got NETv6
```

The UniFi controller API accepts these values and they are required for proper IPv6 firewall rule configuration. The existing `src_address_ipv6` and `dst_address_ipv6` fields already exist in the schema, so the IPv6 network types are the missing piece for full IPv6 firewall rule support.

## Test plan

- [ ] `go build` compiles without errors
- [ ] Verified `tofu plan` accepts `NETv6` / `ADDRv6` values for `src_network_type` and `dst_network_type`
- [ ] Verified `tofu apply` creates IPv6 firewall rules successfully against UniFi controller