### PR TITLE
feat(device): expose `switch_vlan_enabled` on `unifi_device`

### DIFF
--- a/internal/provider/device/resource_device.go
+++ b/internal/provider/device/resource_device.go
@@ -70,6 +70,14 @@ func ResourceDevice() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"switch_vlan_enabled": {
+				Description: "Whether per-port VLAN configuration is enabled on the device. Required for `port_override` blocks with VLAN-tagging profiles (e.g. an IoT-VLAN `port_profile_id`) to actually take effect on access points that expose passthrough Ethernet ports (UAP-UHDIW and similar in-wall units). " +
+					"Switches honor port profile VLAN bindings unconditionally; APs ignore them unless this flag is true. " +
+					"Note: the underlying field uses `omitempty` so setting this to `false` has no effect — once enabled on a device, it can only be disabled via the UI.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"port_override": {
 				// TODO: this should really be a map or something when possible in the SDK
 				// see https://github.com/hashicorp/terraform-plugin-sdk/issues/62
@@ -490,6 +498,7 @@ func resourceDeviceSetResourceData(resp *unifi.Device, d *schema.ResourceData, s
 	d.Set("mac", resp.MAC)
 	d.Set("name", resp.Name)
 	d.Set("disabled", resp.Disabled)
+	d.Set("switch_vlan_enabled", resp.SwitchVLANEnabled)
 	d.Set("port_override", portOverrides)
 	d.Set("radio", radiosFromDevice(resp, d))
 	d.Set("ether_lighting", etherLightingFromDevice(resp, d))
@@ -620,9 +629,10 @@ func resourceDeviceGetResourceData(d *schema.ResourceData) (*unifi.Device, error
 	//TODO: pass Disabled once we figure out how to enable the device afterwards
 
 	return &unifi.Device{
-		MAC:           d.Get("mac").(string),
-		Name:          d.Get("name").(string),
-		PortOverrides: pos,
+		MAC:               d.Get("mac").(string),
+		Name:              d.Get("name").(string),
+		SwitchVLANEnabled: d.Get("switch_vlan_enabled").(bool),
+		PortOverrides:     pos,
 	}, nil
 }
 

--- a/internal/provider/device/resource_device.go
+++ b/internal/provider/device/resource_device.go
@@ -77,6 +77,13 @@ func ResourceDevice() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+				// The controller ignores attempts to disable this (`omitempty` drops
+				// a `false` from the payload), so a `true` -> `false` change would
+				// otherwise read back as `true` and produce a perpetual diff.
+				// Suppress that one transition to match the API's write-once behavior.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "true" && new == "false"
+				},
 			},
 			"port_override": {
 				// TODO: this should really be a map or something when possible in the SDK


### PR DESCRIPTION
## Problem

Access points with passthrough Ethernet ports (the UAP-IW lineage — UAP-AC-IW, UAP-AC-IW-PRO, UHDIW, U7PIW) silently ignore `port_override` VLAN profile bindings unless the controller-side `switch_vlan_enabled` flag is set on the device. Without it, the passthrough port keeps serving the AP's untagged native VLAN regardless of the configured `port_profile_id` — so a Terraform config that *looks* like it puts the port on an IoT VLAN does nothing at L2, with no error anywhere.

The provider has no way to set this flag today, so the only fix is a manual UI toggle outside of Terraform.

## Change

Adds a top-level `switch_vlan_enabled` bool attribute to `unifi_device`, mapped straight through to the existing `Device.SwitchVLANEnabled` field in go-unifi (already present in `v1.8.0` — no client changes needed).

Notes captured in the attribute description:
- Switches honor port profile VLAN bindings unconditionally, so the field only matters on APs; it's exposed everywhere because the underlying go-unifi `Device` struct is unified.
- The field is `omitempty` in go-unifi, so setting `false` from Terraform is a no-op controller-side — once enabled, it can only be disabled via the UI.

## Validation

- `go build ./...` / `go vet` clean against upstream `master` + published `go-unifi v1.8.0`.
- Running in production on my home network since 2026-05-25 (UAP-AC-IW passthrough port bound to an IoT VLAN profile; plan converges, no perpetual diff).