### PR TITLE
feat: Etherlighting support — `ether_lighting` device block + `unifi_setting_ether_lighting`

### DIFF
--- a/internal/provider/device/resource_device.go
+++ b/internal/provider/device/resource_device.go
@@ -165,6 +165,68 @@ func ResourceDevice() *schema.Resource {
 				},
 			},
 
+			"radio": {
+				Description: "Per-band radio configuration for access points. Each block configures ONE band " +
+					"(`ng` = 2.4GHz, `na` = 5GHz, `6e` = 6GHz). Only the bands you declare are managed — undeclared " +
+					"bands are left untouched (the provider read-modify-writes the device's full radio table to preserve " +
+					"them, so declaring just one band will not wipe the others). Common uses: disable a band " +
+					"(`tx_power_mode = \"disabled\"`), pin a channel/width, or set a minimum-RSSI client kick. Applies to " +
+					"access points; has no effect on switches.\n\n" +
+					"Note: like other device fields, only non-zero values are written, so a field cannot be set back to its " +
+					"zero value through Terraform — manage by overriding with explicit non-zero values.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      radioSetHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Description:  "The radio band this block configures: `ng` (2.4GHz), `na` (5GHz), or `6e` (6GHz).",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ng", "na", "6e"}, false),
+						},
+						"channel": {
+							Description: "The channel for this radio (band-specific), or `auto` to let the controller choose.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+						},
+						"ht": {
+							Description:  "Channel width in MHz for this radio (e.g. 20, 40, 80, 160, 320).",
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntInSlice([]int{20, 40, 80, 160, 240, 320, 1080, 2160, 4320}),
+						},
+						"tx_power_mode": {
+							Description:  "Transmit-power mode: `auto`, `low`, `medium`, `high`, `custom`, or `disabled`. `disabled` turns the radio off (e.g. to suppress an unused 2.4GHz band on an in-wall AP).",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"auto", "low", "medium", "high", "custom", "disabled"}, false),
+						},
+						"tx_power": {
+							Description: "Custom transmit power in dBm, used when `tx_power_mode = \"custom\"`; otherwise leave unset.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+						},
+						"min_rssi_enabled": {
+							Description: "Whether the minimum-RSSI client-disconnect threshold is enabled on this radio. Applied together with `min_rssi`.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+						},
+						"min_rssi": {
+							Description: "Minimum RSSI in dBm (negative) below which clients are disconnected, when `min_rssi_enabled` is true.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+
 			"allow_adoption": {
 				Description: "Whether to automatically adopt the device when creating this resource. When true:\n" +
 					"* The controller will attempt to adopt the device\n" +
@@ -284,6 +346,19 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	req.ID = d.Id()
 	req.SiteID = site
 
+	// Radio table is a controller-side array that UniFi replaces wholesale on
+	// PUT. To manage only the bands the user declares (and avoid wiping the
+	// others), read the device's current radio_table and overlay the declared
+	// bands onto it, sending the full merged list. When no radio blocks are
+	// declared, RadioTable stays nil (omitempty) and radios are left untouched.
+	if radios := d.Get("radio").(*schema.Set); radios.Len() > 0 {
+		current, err := c.GetDevice(ctx, site, d.Id())
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("unable to read current device radio table for merge: %w", err))
+		}
+		req.RadioTable = mergeRadios(current.RadioTable, radios)
+	}
+
 	resp, err := c.UpdateDevice(ctx, site, req)
 	if err != nil {
 		return diag.FromErr(err)
@@ -365,8 +440,90 @@ func resourceDeviceSetResourceData(resp *unifi.Device, d *schema.ResourceData, s
 	d.Set("name", resp.Name)
 	d.Set("disabled", resp.Disabled)
 	d.Set("port_override", portOverrides)
+	d.Set("radio", radiosFromDevice(resp, d))
 
 	return nil
+}
+
+// radioSetHash keys the `radio` set by band only, so changes to Computed
+// fields (channel, ht, …) don't churn set membership during plan/apply.
+func radioSetHash(v interface{}) int {
+	m := v.(map[string]interface{})
+	return schema.HashString(m["name"].(string))
+}
+
+// radiosFromDevice returns radio state for only the bands the user manages
+// (present in config/state), so undeclared bands on the device never produce
+// a diff.
+func radiosFromDevice(resp *unifi.Device, d *schema.ResourceData) []map[string]interface{} {
+	managed := map[string]bool{}
+	for _, item := range d.Get("radio").(*schema.Set).List() {
+		managed[item.(map[string]interface{})["name"].(string)] = true
+	}
+	radios := make([]map[string]interface{}, 0, len(managed))
+	for _, r := range resp.RadioTable {
+		if managed[r.Radio] {
+			radios = append(radios, fromRadio(r))
+		}
+	}
+	return radios
+}
+
+func fromRadio(r unifi.DeviceRadioTable) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             r.Radio,
+		"channel":          r.Channel,
+		"ht":               r.Ht,
+		"tx_power_mode":    r.TxPowerMode,
+		"tx_power":         r.TxPower,
+		"min_rssi":         r.MinRssi,
+		"min_rssi_enabled": r.MinRssiEnabled,
+	}
+}
+
+// mergeRadios overlays the declared radio blocks onto the device's current
+// radio_table, preserving every band's existing settings and changing only the
+// non-zero fields the user specified. Bands not present in `current` are
+// appended. The full merged list is returned so the wholesale-replace PUT keeps
+// all bands intact.
+func mergeRadios(current []unifi.DeviceRadioTable, set *schema.Set) []unifi.DeviceRadioTable {
+	byBand := map[string]unifi.DeviceRadioTable{}
+	order := make([]string, 0, len(current))
+	for _, r := range current {
+		byBand[r.Radio] = r
+		order = append(order, r.Radio)
+	}
+	for _, item := range set.List() {
+		m := item.(map[string]interface{})
+		band := m["name"].(string)
+		r, ok := byBand[band]
+		if !ok {
+			r = unifi.DeviceRadioTable{Radio: band}
+			order = append(order, band)
+		}
+		if v, _ := m["channel"].(string); v != "" {
+			r.Channel = v
+		}
+		if v, _ := m["ht"].(int); v != 0 {
+			r.Ht = v
+		}
+		if v, _ := m["tx_power_mode"].(string); v != "" {
+			r.TxPowerMode = v
+		}
+		if v, _ := m["tx_power"].(string); v != "" {
+			r.TxPower = v
+		}
+		if v, _ := m["min_rssi"].(int); v != 0 {
+			r.MinRssi = v
+			r.MinRssiEnabled = m["min_rssi_enabled"].(bool)
+		}
+		byBand[band] = r
+	}
+	out := make([]unifi.DeviceRadioTable, 0, len(order))
+	for _, b := range order {
+		out = append(out, byBand[b])
+	}
+	return out
 }
 
 func resourceDeviceGetResourceData(d *schema.ResourceData) (*unifi.Device, error) {

--- a/internal/provider/device/resource_device.go
+++ b/internal/provider/device/resource_device.go
@@ -227,6 +227,49 @@ func ResourceDevice() *schema.Resource {
 				},
 			},
 
+			"ether_lighting": {
+				Description: "Etherlighting configuration for switches with per-port LEDs (e.g. USW Pro Max). " +
+					"`mode = \"network\"` colors each port's LED by the VLAN/network it serves (per-network colors come from " +
+					"the site-level Etherlighting palette); `mode = \"speed\"` colors by link speed. Only the fields you set " +
+					"are written — unset fields keep their controller-side values (read-modify-write overlay). Devices without " +
+					"Etherlighting hardware ignore this object.",
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Description:  "Color scheme: `network` (color by VLAN/network) or `speed` (color by link speed).",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"network", "speed"}, false),
+						},
+						"led_mode": {
+							Description:  "`etherlighting` (colored per-port LEDs) or `standard` (plain status LEDs).",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"etherlighting", "standard"}, false),
+						},
+						"behavior": {
+							Description:  "LED animation: `steady` or `breath`.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"steady", "breath"}, false),
+						},
+						"brightness": {
+							Description:  "LED brightness, 1-100.",
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(1, 100),
+						},
+					},
+				},
+			},
+
 			"allow_adoption": {
 				Description: "Whether to automatically adopt the device when creating this resource. When true:\n" +
 					"* The controller will attempt to adopt the device\n" +
@@ -346,17 +389,25 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	req.ID = d.Id()
 	req.SiteID = site
 
-	// Radio table is a controller-side array that UniFi replaces wholesale on
-	// PUT. To manage only the bands the user declares (and avoid wiping the
-	// others), read the device's current radio_table and overlay the declared
-	// bands onto it, sending the full merged list. When no radio blocks are
-	// declared, RadioTable stays nil (omitempty) and radios are left untouched.
-	if radios := d.Get("radio").(*schema.Set); radios.Len() > 0 {
+	// Radio table and Etherlighting are controller-side structures managed
+	// with patch semantics: fetch the device's current config once and overlay
+	// only the declared fields, so undeclared bands/fields keep their
+	// controller-side values. (Radio table additionally needs the full merged
+	// array sent because UniFi replaces arrays wholesale on PUT.) When neither
+	// block is declared, nothing extra is sent (prior behavior).
+	radios := d.Get("radio").(*schema.Set)
+	etherLighting := d.Get("ether_lighting").([]interface{})
+	if radios.Len() > 0 || len(etherLighting) > 0 {
 		current, err := c.GetDevice(ctx, site, d.Id())
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("unable to read current device radio table for merge: %w", err))
+			return diag.FromErr(fmt.Errorf("unable to read current device config for merge: %w", err))
 		}
-		req.RadioTable = mergeRadios(current.RadioTable, radios)
+		if radios.Len() > 0 {
+			req.RadioTable = mergeRadios(current.RadioTable, radios)
+		}
+		if len(etherLighting) > 0 {
+			req.EtherLighting = mergeEtherLighting(current.EtherLighting, etherLighting[0].(map[string]interface{}))
+		}
 	}
 
 	resp, err := c.UpdateDevice(ctx, site, req)
@@ -441,8 +492,42 @@ func resourceDeviceSetResourceData(resp *unifi.Device, d *schema.ResourceData, s
 	d.Set("disabled", resp.Disabled)
 	d.Set("port_override", portOverrides)
 	d.Set("radio", radiosFromDevice(resp, d))
+	d.Set("ether_lighting", etherLightingFromDevice(resp, d))
 
 	return nil
+}
+
+// etherLightingFromDevice returns ether_lighting state only when the user
+// declares the block, so unmanaged devices never produce a diff.
+func etherLightingFromDevice(resp *unifi.Device, d *schema.ResourceData) []map[string]interface{} {
+	if len(d.Get("ether_lighting").([]interface{})) == 0 {
+		return nil
+	}
+	return []map[string]interface{}{{
+		"mode":       resp.EtherLighting.Mode,
+		"led_mode":   resp.EtherLighting.LedMode,
+		"behavior":   resp.EtherLighting.Behavior,
+		"brightness": resp.EtherLighting.Brightness,
+	}}
+}
+
+// mergeEtherLighting overlays the declared ether_lighting fields onto the
+// device's current config, preserving any fields the user didn't set.
+func mergeEtherLighting(current unifi.DeviceEtherLighting, m map[string]interface{}) unifi.DeviceEtherLighting {
+	r := current
+	if v, _ := m["mode"].(string); v != "" {
+		r.Mode = v
+	}
+	if v, _ := m["led_mode"].(string); v != "" {
+		r.LedMode = v
+	}
+	if v, _ := m["behavior"].(string); v != "" {
+		r.Behavior = v
+	}
+	if v, _ := m["brightness"].(int); v != 0 {
+		r.Brightness = v
+	}
+	return r
 }
 
 // radioSetHash keys the `radio` set by band only, so changes to Computed

--- a/internal/provider/device/resource_device_test.go
+++ b/internal/provider/device/resource_device_test.go
@@ -1,0 +1,94 @@
+package device
+
+import (
+	"testing"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func radioSet(items ...map[string]interface{}) *schema.Set {
+	raw := make([]interface{}, len(items))
+	for i, m := range items {
+		raw[i] = m
+	}
+	return schema.NewSet(radioSetHash, raw)
+}
+
+func radioByBand(rs []unifi.DeviceRadioTable, band string) (unifi.DeviceRadioTable, bool) {
+	for _, r := range rs {
+		if r.Radio == band {
+			return r, true
+		}
+	}
+	return unifi.DeviceRadioTable{}, false
+}
+
+// The core safety property: declaring one band must not wipe the others.
+func TestMergeRadios_PreservesUndeclaredBands(t *testing.T) {
+	current := []unifi.DeviceRadioTable{
+		{Radio: "ng", Channel: "1", Ht: 20, TxPowerMode: "auto"},
+		{Radio: "na", Channel: "36", Ht: 80, TxPowerMode: "high"},
+		{Radio: "6e", Channel: "37", Ht: 160, TxPowerMode: "auto"},
+	}
+	got := mergeRadios(current, radioSet(map[string]interface{}{
+		"name": "ng", "tx_power_mode": "disabled",
+	}))
+	if len(got) != 3 {
+		t.Fatalf("expected all 3 bands preserved, got %d: %+v", len(got), got)
+	}
+	ng, _ := radioByBand(got, "ng")
+	if ng.TxPowerMode != "disabled" {
+		t.Errorf("ng tx_power_mode = %q, want disabled", ng.TxPowerMode)
+	}
+	if ng.Channel != "1" || ng.Ht != 20 {
+		t.Errorf("ng channel/ht clobbered: got channel=%q ht=%d, want 1/20", ng.Channel, ng.Ht)
+	}
+	if na, _ := radioByBand(got, "na"); na.Channel != "36" || na.Ht != 80 || na.TxPowerMode != "high" {
+		t.Errorf("na band modified: %+v", na)
+	}
+	if sixE, _ := radioByBand(got, "6e"); sixE.Channel != "37" || sixE.Ht != 160 {
+		t.Errorf("6e band modified: %+v", sixE)
+	}
+}
+
+// Only non-zero declared fields overlay; unset fields keep the controller value.
+func TestMergeRadios_OverlaysOnlyNonZero(t *testing.T) {
+	current := []unifi.DeviceRadioTable{{Radio: "ng", Channel: "6", Ht: 40, TxPowerMode: "medium"}}
+	got := mergeRadios(current, radioSet(map[string]interface{}{
+		"name": "ng", "channel": "11",
+	}))
+	ng, _ := radioByBand(got, "ng")
+	if ng.Channel != "11" {
+		t.Errorf("channel = %q, want 11", ng.Channel)
+	}
+	if ng.Ht != 40 || ng.TxPowerMode != "medium" {
+		t.Errorf("unset fields clobbered: ht=%d tx_power_mode=%q, want 40/medium", ng.Ht, ng.TxPowerMode)
+	}
+}
+
+// A declared band missing from the device is appended.
+func TestMergeRadios_AppendsMissingBand(t *testing.T) {
+	current := []unifi.DeviceRadioTable{{Radio: "na", Channel: "36"}}
+	got := mergeRadios(current, radioSet(map[string]interface{}{
+		"name": "ng", "tx_power_mode": "disabled",
+	}))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bands, got %d", len(got))
+	}
+	if ng, ok := radioByBand(got, "ng"); !ok || ng.TxPowerMode != "disabled" {
+		t.Errorf("ng not appended correctly: %+v ok=%v", ng, ok)
+	}
+}
+
+// min_rssi pairs with min_rssi_enabled only when a non-zero threshold is set.
+func TestMergeRadios_MinRssiPairing(t *testing.T) {
+	current := []unifi.DeviceRadioTable{{Radio: "na"}}
+	got := mergeRadios(current, radioSet(map[string]interface{}{
+		"name": "na", "min_rssi": -75, "min_rssi_enabled": true,
+	}))
+	na, _ := radioByBand(got, "na")
+	if na.MinRssi != -75 || !na.MinRssiEnabled {
+		t.Errorf("min_rssi pairing failed: %+v", na)
+	}
+}

--- a/internal/provider/device/resource_device_test.go
+++ b/internal/provider/device/resource_device_test.go
@@ -92,3 +92,22 @@ func TestMergeRadios_MinRssiPairing(t *testing.T) {
 		t.Errorf("min_rssi pairing failed: %+v", na)
 	}
 }
+
+// Etherlighting overlay: declared fields apply; unset fields keep current values.
+func TestMergeEtherLighting_OverlaysOnlyNonZero(t *testing.T) {
+	current := unifi.DeviceEtherLighting{Mode: "speed", Brightness: 80, Behavior: "steady", LedMode: "etherlighting"}
+	got := mergeEtherLighting(current, map[string]interface{}{"mode": "network"})
+	if got.Mode != "network" {
+		t.Errorf("mode = %q, want network", got.Mode)
+	}
+	if got.Brightness != 80 || got.Behavior != "steady" || got.LedMode != "etherlighting" {
+		t.Errorf("unset fields clobbered: %+v", got)
+	}
+}
+
+func TestMergeEtherLighting_FromEmptyCurrent(t *testing.T) {
+	got := mergeEtherLighting(unifi.DeviceEtherLighting{}, map[string]interface{}{"mode": "network", "brightness": 60})
+	if got.Mode != "network" || got.Brightness != 60 || got.Behavior != "" {
+		t.Errorf("unexpected merge from empty: %+v", got)
+	}
+}

--- a/internal/provider/provider_v2.go
+++ b/internal/provider/provider_v2.go
@@ -198,6 +198,7 @@ func (p *unifiProvider) Resources(_ context.Context) []func() resource.Resource 
 		settings.NewAutoSpeedtestResource,
 		settings.NewCountryResource,
 		settings.NewDpiResource,
+		settings.NewEtherLightingResource,
 		settings.NewGuestAccessResource,
 		settings.NewIpsResource,
 		settings.NewLcmResource,

--- a/internal/provider/settings/resource_setting_ether_lighting.go
+++ b/internal/provider/settings/resource_setting_ether_lighting.go
@@ -1,0 +1,223 @@
+package settings
+
+import (
+	"context"
+	"regexp"
+
+	ut "github.com/filipowm/terraform-provider-unifi/internal/provider/types"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var colorHexRegexp = regexp.MustCompile(`^[0-9A-Fa-f]{6}$`)
+
+type etherLightingNetworkOverrideModel struct {
+	NetworkID types.String `tfsdk:"network_id"`
+	ColorHex  types.String `tfsdk:"color_hex"`
+}
+
+func (m *etherLightingNetworkOverrideModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"network_id": types.StringType,
+		"color_hex":  types.StringType,
+	}
+}
+
+type etherLightingSpeedOverrideModel struct {
+	Speed    types.String `tfsdk:"speed"`
+	ColorHex types.String `tfsdk:"color_hex"`
+}
+
+func (m *etherLightingSpeedOverrideModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"speed":     types.StringType,
+		"color_hex": types.StringType,
+	}
+}
+
+type etherLightingModel struct {
+	base.Model
+	NetworkOverrides types.Set `tfsdk:"network_overrides"`
+	SpeedOverrides   types.Set `tfsdk:"speed_overrides"`
+}
+
+func (d *etherLightingModel) AsUnifiModel(ctx context.Context) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	model := &unifi.SettingEtherLighting{
+		ID: d.ID.ValueString(),
+	}
+
+	if ut.IsDefined(d.NetworkOverrides) {
+		var overrides []etherLightingNetworkOverrideModel
+		diags.Append(d.NetworkOverrides.ElementsAs(ctx, &overrides, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		model.NetworkOverrides = make([]unifi.SettingEtherLightingNetworkOverrides, 0, len(overrides))
+		for _, o := range overrides {
+			model.NetworkOverrides = append(model.NetworkOverrides, unifi.SettingEtherLightingNetworkOverrides{
+				Key:         o.NetworkID.ValueString(),
+				RawColorHex: o.ColorHex.ValueString(),
+			})
+		}
+	}
+
+	if ut.IsDefined(d.SpeedOverrides) {
+		var overrides []etherLightingSpeedOverrideModel
+		diags.Append(d.SpeedOverrides.ElementsAs(ctx, &overrides, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		model.SpeedOverrides = make([]unifi.SettingEtherLightingSpeedOverrides, 0, len(overrides))
+		for _, o := range overrides {
+			model.SpeedOverrides = append(model.SpeedOverrides, unifi.SettingEtherLightingSpeedOverrides{
+				Key:         o.Speed.ValueString(),
+				RawColorHex: o.ColorHex.ValueString(),
+			})
+		}
+	}
+
+	return model, diags
+}
+
+func (d *etherLightingModel) Merge(ctx context.Context, other interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model, ok := other.(*unifi.SettingEtherLighting)
+	if !ok {
+		diags.AddError("Cannot merge", "Cannot merge type that is not *unifi.SettingEtherLighting")
+		return diags
+	}
+
+	d.ID = types.StringValue(model.ID)
+
+	networkModels := make([]etherLightingNetworkOverrideModel, 0, len(model.NetworkOverrides))
+	for _, o := range model.NetworkOverrides {
+		networkModels = append(networkModels, etherLightingNetworkOverrideModel{
+			NetworkID: types.StringValue(o.Key),
+			ColorHex:  types.StringValue(o.RawColorHex),
+		})
+	}
+	networkList, networkDiags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: (&etherLightingNetworkOverrideModel{}).AttributeTypes()}, networkModels)
+	diags.Append(networkDiags...)
+	if diags.HasError() {
+		return diags
+	}
+	d.NetworkOverrides = networkList
+
+	speedModels := make([]etherLightingSpeedOverrideModel, 0, len(model.SpeedOverrides))
+	for _, o := range model.SpeedOverrides {
+		speedModels = append(speedModels, etherLightingSpeedOverrideModel{
+			Speed:    types.StringValue(o.Key),
+			ColorHex: types.StringValue(o.RawColorHex),
+		})
+	}
+	speedList, speedDiags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: (&etherLightingSpeedOverrideModel{}).AttributeTypes()}, speedModels)
+	diags.Append(speedDiags...)
+	if diags.HasError() {
+		return diags
+	}
+	d.SpeedOverrides = speedList
+
+	return diags
+}
+
+var (
+	_ base.ResourceModel               = &etherLightingModel{}
+	_ resource.Resource                = &etherLightingResource{}
+	_ resource.ResourceWithConfigure   = &etherLightingResource{}
+	_ resource.ResourceWithImportState = &etherLightingResource{}
+)
+
+type etherLightingResource struct {
+	*base.GenericResource[*etherLightingModel]
+}
+
+func (r *etherLightingResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages the site-level Etherlighting palette — the colors that switches with per-port LEDs " +
+			"(USW Pro Max line) use when a device's `ether_lighting` block selects a scheme. `network_overrides` assigns a " +
+			"color per network/VLAN (used by `mode = \"network\"`); `speed_overrides` assigns a color per link-speed class " +
+			"(used by `mode = \"speed\"`). Overrides take precedence over the controller's built-in default palette; " +
+			"networks or speeds without an override keep their default color. NOTE: the controller silently drops any override whose color equals that network's built-in default — declare only colors that actually differ from the defaults, or the entry will not round-trip.",
+		Attributes: map[string]schema.Attribute{
+			"id":   ut.ID(),
+			"site": ut.SiteAttribute(),
+			"network_overrides": schema.SetNestedAttribute{
+				MarkdownDescription: "Per-network LED colors, used when a device's Etherlighting `mode` is `network`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"network_id": schema.StringAttribute{
+							MarkdownDescription: "ID of the network/VLAN this color applies to (e.g. `unifi_network.iot.id`).",
+							Required:            true,
+						},
+						"color_hex": schema.StringAttribute{
+							MarkdownDescription: "LED color as a 6-digit RGB hex string without `#` (e.g. `ff6c14`).",
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(colorHexRegexp, "must be a 6-digit RGB hex string without '#'"),
+							},
+						},
+					},
+				},
+			},
+			"speed_overrides": schema.SetNestedAttribute{
+				MarkdownDescription: "Per-link-speed LED colors, used when a device's Etherlighting `mode` is `speed`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"speed": schema.StringAttribute{
+							MarkdownDescription: "Link-speed class this color applies to.",
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("FE", "GbE", "2.5GbE", "5GbE", "10GbE", "25GbE", "40GbE", "100GbE"),
+							},
+						},
+						"color_hex": schema.StringAttribute{
+							MarkdownDescription: "LED color as a 6-digit RGB hex string without `#` (e.g. `ffc107`).",
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(colorHexRegexp, "must be a 6-digit RGB hex string without '#'"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewEtherLightingResource() resource.Resource {
+	r := &etherLightingResource{}
+	r.GenericResource = NewSettingResource(
+		"unifi_setting_ether_lighting",
+		func() *etherLightingModel { return &etherLightingModel{} },
+		func(ctx context.Context, client *base.Client, site string) (interface{}, error) {
+			return client.GetSettingEtherLighting(ctx, site)
+		},
+		func(ctx context.Context, client *base.Client, site string, body interface{}) (interface{}, error) {
+			return client.UpdateSettingEtherLighting(ctx, site, body.(*unifi.SettingEtherLighting))
+		},
+	)
+	return r
+}

--- a/internal/provider/settings/resource_setting_ether_lighting.go
+++ b/internal/provider/settings/resource_setting_ether_lighting.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	ut "github.com/filipowm/terraform-provider-unifi/internal/provider/types"
@@ -64,10 +65,20 @@ func (d *etherLightingModel) AsUnifiModel(ctx context.Context) (interface{}, dia
 		if diags.HasError() {
 			return nil, diags
 		}
+		// A set of objects only dedupes on the whole object, so two entries
+		// sharing a network_id but differing in color_hex both survive and
+		// would forward conflicting colors for the same key. Reject that.
+		seen := make(map[string]struct{}, len(overrides))
 		model.NetworkOverrides = make([]unifi.SettingEtherLightingNetworkOverrides, 0, len(overrides))
 		for _, o := range overrides {
+			key := o.NetworkID.ValueString()
+			if _, dup := seen[key]; dup {
+				diags.AddError("Duplicate network_overrides entry", fmt.Sprintf("network_id %q appears more than once in network_overrides; each network may set only one color.", key))
+				return nil, diags
+			}
+			seen[key] = struct{}{}
 			model.NetworkOverrides = append(model.NetworkOverrides, unifi.SettingEtherLightingNetworkOverrides{
-				Key:         o.NetworkID.ValueString(),
+				Key:         key,
 				RawColorHex: o.ColorHex.ValueString(),
 			})
 		}
@@ -79,10 +90,17 @@ func (d *etherLightingModel) AsUnifiModel(ctx context.Context) (interface{}, dia
 		if diags.HasError() {
 			return nil, diags
 		}
+		seen := make(map[string]struct{}, len(overrides))
 		model.SpeedOverrides = make([]unifi.SettingEtherLightingSpeedOverrides, 0, len(overrides))
 		for _, o := range overrides {
+			key := o.Speed.ValueString()
+			if _, dup := seen[key]; dup {
+				diags.AddError("Duplicate speed_overrides entry", fmt.Sprintf("speed %q appears more than once in speed_overrides; each speed may set only one color.", key))
+				return nil, diags
+			}
+			seen[key] = struct{}{}
 			model.SpeedOverrides = append(model.SpeedOverrides, unifi.SettingEtherLightingSpeedOverrides{
-				Key:         o.Speed.ValueString(),
+				Key:         key,
 				RawColorHex: o.ColorHex.ValueString(),
 			})
 		}


### PR DESCRIPTION
> **Stacked on #128** — the device-block commit shares the current-device GET introduced by the radio block's read-modify-write update, so this branch includes #128's commit. Review the **top 2 commits**; once #128 merges this will rebase down to just those.

## What

Two halves of UniFi Etherlighting (per-port LEDs on the USW Pro Max line) support:

1. **`ether_lighting` block on `unifi_device`** (single nested object) — `mode` (`network` = color by VLAN, `speed` = color by link speed), `led_mode` (`etherlighting`/`standard`), `behavior` (`steady`/`breath`), `brightness` (1-100). Same patch semantics as the radio block: state is read only when the block is declared, and updates overlay only non-zero declared fields onto the device's current config via read-modify-write. Devices without Etherlighting hardware ignore the object.

2. **`unifi_setting_ether_lighting`** — site-level color palette consumed by devices in (1): `network_overrides` (color per network, for `mode = "network"`) and `speed_overrides` (color per link-speed class `FE`…`100GbE`, for `mode = "speed"`). Colors are validated 6-digit RGB hex. Plugin-framework resource following the `GenericResource` settings pattern (`SettingUsw`/`SettingIps` precedents). go-unifi `v1.8.0` already provides `SettingEtherLighting` and client methods — no client change.

### Controller quirks handled

- The palette uses `SetNestedAttribute` (not a list): the controller normalizes/reorders override entries, which breaks list-based post-apply consistency checks.
- The controller **silently drops an override whose color equals that network's built-in default** (it doesn't round-trip). Documented in the attribute description so users declare only non-default colors instead of hitting "inconsistent result after apply".

## Validation

- Unit tests cover the device-block overlay merge (preserves unset fields, merge-from-empty).
- `go build ./...` / `go vet` / `go test` clean against upstream `master` + published `go-unifi v1.8.0`.
- Running in production on my home network since 2026-06-03: a USW switch on `mode = "network"` with a 4-network palette; plan converges after apply.