### PR TITLE
feat(network): expose `upnp_lan_enabled` on `unifi_network`

### DIFF
--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -290,6 +290,17 @@ func ResourceNetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"upnp_lan_enabled": {
+				Description: "Whether clients on THIS network are allowed to request UPnP/NAT-PMP port mappings. " +
+					"Per-network opt-in that complements the gateway-global UPnP toggle " +
+					"(`unifi_setting_usg.upnp_enabled`): UPnP must be enabled globally AND on a given network for that " +
+					"network's devices to self-map WAN ports. Leave false on untrusted networks (IoT, Guest, …) so a " +
+					"compromised device cannot open inbound holes in the firewall; enable only on networks whose devices " +
+					"you trust to manage their own port mappings.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"ipv6_interface_type": {
 				Description: "Specifies the IPv6 connection type. Must be one of:\n" +
 					"* `none` - IPv6 disabled (default)\n" +
@@ -589,6 +600,7 @@ func resourceNetworkGetResourceData(d *schema.ResourceData, meta interface{}) (*
 		DHCPRelayEnabled:  d.Get("dhcp_relay_enabled").(bool),
 		DomainName:        d.Get("domain_name").(string),
 		IGMPSnooping:      d.Get("igmp_snooping").(bool),
+		UpnpLanEnabled:    d.Get("upnp_lan_enabled").(bool),
 		MdnsEnabled:       d.Get("multicast_dns").(bool),
 		Enabled:           d.Get("enabled").(bool),
 
@@ -744,6 +756,7 @@ func resourceNetworkSetResourceData(resp *unifi.Network, d *schema.ResourceData,
 	d.Set("domain_name", resp.DomainName)
 	d.Set("enabled", resp.Enabled)
 	d.Set("igmp_snooping", resp.IGMPSnooping)
+	d.Set("upnp_lan_enabled", resp.UpnpLanEnabled)
 	d.Set("internet_access_enabled", resp.InternetAccessEnabled)
 	d.Set("network_isolation_enabled", resp.NetworkIsolationEnabled)
 	d.Set("ipv6_interface_type", resp.IPV6InterfaceType)


### PR DESCRIPTION
## Problem

The gateway-global UPnP toggle (`unifi_setting_usg.upnp_enabled`) is all-or-nothing from Terraform's perspective, but the controller actually gates UPnP per network: a client may self-map WAN ports only if its network's `upnp_lan_enabled` is also set. The provider doesn't expose that flag, so the per-network scoping — the part that makes UPnP defensible — can only be set in the UI.

## Change

Adds `upnp_lan_enabled` (bool, Optional+Computed) to `unifi_network`, wired through the existing `igmp_snooping`/`multicast_dns` pattern (schema + get + set). `go-unifi v1.8.0` already has `Network.UpnpLanEnabled` — no client change.

This makes the security-relevant configuration declarative: enable UPnP on a trusted network only (e.g. so Plex keeps auto-mapping its remote-access port) while keeping it explicitly `false` on IoT/Guest networks, where a compromised device could otherwise open arbitrary inbound holes.

## Validation

- `go build ./...` / `go vet` clean against upstream `master` + published `go-unifi v1.8.0`.
- Running in production on my home network since 2026-06-04: UPnP scoped to one trusted VLAN (Plex remote access auto-maps correctly), explicitly disabled on three others; plan converges after apply.