### PR TITLE
feat(wlan): expose `wlan_bands` on `unifi_wlan` for multi-band (incl. 6GHz) selection

### DIFF
--- a/internal/provider/acctest/resource_wlan_test.go
+++ b/internal/provider/acctest/resource_wlan_test.go
@@ -163,6 +163,26 @@ func TestAccWLAN_wlan_band(t *testing.T) {
 	})
 }
 
+func TestAccWLAN_wlan_bands(t *testing.T) {
+	name := acctest.RandomWithPrefix("tfacc")
+	subnet, vlan := pt.GetTestVLAN(t)
+
+	AcceptanceTest(t, AcceptanceTestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWLANConfig_wlan_bands(name, subnet, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_wlan.test", "wlan_bands.#", "2"),
+					resource.TestCheckTypeSetElemAttr("unifi_wlan.test", "wlan_bands.*", "2g"),
+					resource.TestCheckTypeSetElemAttr("unifi_wlan.test", "wlan_bands.*", "5g"),
+					resource.TestCheckResourceAttr("unifi_wlan.test", "wlan_band", "both"),
+				),
+			},
+			pt.ImportStep("unifi_wlan.test"),
+		},
+	})
+}
+
 func TestAccWLAN_no2ghz_oui(t *testing.T) {
 	name := acctest.RandomWithPrefix("tfacc")
 	subnet, vlan := pt.GetTestVLAN(t)
@@ -454,6 +474,21 @@ resource "unifi_wlan" "test" {
 	user_group_id     = data.unifi_user_group.default.id
 	security          = "wpapsk"
 	wlan_band         = "5g"
+	multicast_enhance = true
+}
+`, name)
+}
+
+func testAccWLANConfig_wlan_bands(name string, subnet *net.IPNet, vlan int) string {
+	return testAccWLANBaseConfig(name, subnet, vlan) + fmt.Sprintf(`
+resource "unifi_wlan" "test" {
+	name              = "%[1]s-wpapsk"
+	network_id        = unifi_network.test.id
+	passphrase        = "12345678"
+	ap_group_ids      = [data.unifi_ap_group.default.id]
+	user_group_id     = data.unifi_user_group.default.id
+	security          = "wpapsk"
+	wlan_bands        = ["2g", "5g"]
 	multicast_enhance = true
 }
 `, name)

--- a/internal/provider/acctest/resource_wlan_test.go
+++ b/internal/provider/acctest/resource_wlan_test.go
@@ -169,6 +169,16 @@ func TestAccWLAN_wlan_bands(t *testing.T) {
 
 	AcceptanceTest(t, AcceptanceTestCase{
 		Steps: []resource.TestStep{
+			// Start on the legacy single-band field, then switch to wlan_bands.
+			// This exercises the wlan_band -> wlan_bands handoff in
+			// resourceWLANGetResourceData and proves the stale Computed array
+			// from the first step is not echoed back over the new config.
+			{
+				Config: testAccWLANConfig_wlan_band(name, subnet, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_wlan.test", "wlan_band", "5g"),
+				),
+			},
 			{
 				Config: testAccWLANConfig_wlan_bands(name, subnet, vlan),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/network/resource_wlan.go
+++ b/internal/provider/network/resource_wlan.go
@@ -236,14 +236,32 @@ func ResourceWLAN() *schema.Resource {
 				ValidateFunc: validation.IntInSlice(append([]int{0}, wlanValidMinimumDataRate5g...)),
 			},
 			"wlan_band": {
-				Description: "Radio band selection. Valid values:\n" +
-					"  * `both` - Both 2.4GHz and 5GHz (default)\n" +
+				Description: "Radio band selection (legacy single-band field). Valid values:\n" +
+					"  * `both` - Both 2.4GHz and 5GHz\n" +
 					"  * `2g` - 2.4GHz only\n" +
-					"  * `5g` - 5GHz only",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"2g", "5g", "both"}, false),
-				Default:      "both",
+					"  * `5g` - 5GHz only\n\n" +
+					"Cannot express a 6GHz selection — use `wlan_bands` for that. When neither this nor `wlan_bands` is set, " +
+					"the controller's default (all supported bands) applies.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.StringInSlice([]string{"2g", "5g", "both"}, false),
+				ConflictsWith: []string{"wlan_bands"},
+			},
+			"wlan_bands": {
+				Description: "Radio bands to broadcast this SSID on (modern multi-band field, supersedes `wlan_band` and supports 6GHz). " +
+					"Valid values for each element: `2g`, `5g`, `6g`. Note that 6GHz requires WPA3 (or WPA3 transition mode) and a " +
+					"6GHz-capable access point. When set, the legacy `wlan_band` field is derived from it and `setting_preference` " +
+					"is forced to `manual`, matching UniFi UI behavior.",
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				MinItems:      1,
+				ConflictsWith: []string{"wlan_band"},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"2g", "5g", "6g"}, false),
+				},
 			},
 			"network_id": {
 				Description: "ID of the network (VLAN) for this SSID. Used to assign the WLAN to a specific network segment.",
@@ -312,6 +330,37 @@ func resourceWLANGetResourceData(d *schema.ResourceData, meta interface{}) (*uni
 	}
 	wlanBand := d.Get("wlan_band").(string)
 
+	// Only send wlan_bands when it is explicitly configured. The attribute is
+	// Computed, so d.Get also returns controller-derived state for configs
+	// that only set the legacy wlan_band — echoing that stale array back
+	// would override a wlan_band change.
+	wlanBands, err := utils.SetToStringSlice(d.Get("wlan_bands").(*schema.Set))
+	if err != nil {
+		return nil, err
+	}
+	bandsConfigured := false
+	if raw := d.GetRawConfig(); !raw.IsNull() {
+		bandsConfigured = !raw.GetAttr("wlan_bands").IsNull()
+	}
+	settingPreference := ""
+	if bandsConfigured {
+		// wlan_bands is authoritative — but ONLY if the legacy wlan_band
+		// string is absent from the payload. The controller derives
+		// wlan_bands FROM a present wlan_band and ignores the array we send:
+		// empirically wlan_band="5g" + wlan_bands=["5g","6g"] persisted
+		// ["5g"], and wlan_band="both" + the same array persisted ["2g","5g"]
+		// (i.e. "both" expands to 2.4+5, NOT a permissive "defer to the
+		// array"). The legacy enum (2g/5g/both) can't even express
+		// ["5g","6g"]. So we must OMIT wlan_band entirely: it has omitempty,
+		// so leaving it "" drops it from the JSON and the controller honors
+		// wlan_bands as given. Pin setting_preference to manual the way the
+		// UI does when bands are hand-picked.
+		wlanBand = ""
+		settingPreference = "manual"
+	} else {
+		wlanBands = nil
+	}
+
 	schedule, err := listToSchedules(d.Get("schedule").([]interface{}))
 	if err != nil {
 		return nil, fmt.Errorf("unable to process schedule block: %w", err)
@@ -345,6 +394,8 @@ func resourceWLANGetResourceData(d *schema.ResourceData, meta interface{}) (*uni
 		ScheduleWithDuration:    schedule,
 		ScheduleEnabled:         len(schedule) > 0,
 		WLANBand:                wlanBand,
+		WLANBands:               wlanBands,
+		SettingPreference:       settingPreference,
 		PMFMode:                 pmf,
 
 		// TODO: add to schema
@@ -437,6 +488,7 @@ func resourceWLANSetResourceData(resp *unifi.WLAN, d *schema.ResourceData, meta 
 	d.Set("radius_profile_id", resp.RADIUSProfileID)
 	d.Set("schedule", schedule)
 	d.Set("wlan_band", resp.WLANBand)
+	d.Set("wlan_bands", utils.StringSliceToSet(resp.WLANBands))
 	d.Set("no2ghz_oui", resp.No2GhzOui)
 	d.Set("l2_isolation", resp.L2Isolation)
 	d.Set("proxy_arp", resp.ProxyArp)


### PR DESCRIPTION
## What

Adds a `wlan_bands` set attribute (`2g`/`5g`/`6g`) to `unifi_wlan` — the modern multi-band field that supersedes the legacy single-band `wlan_band` enum (`2g`/`5g`/`both`). It's the only way to express a **6GHz** selection (e.g. a 5 + 6 GHz SSID that drops 2.4), which `wlan_band` cannot represent.

`go-unifi` v1.9.2 already carries `WLAN.WLANBands` (and `SettingPreference`), so this is **provider-only** — same shape as the recently-merged `switch_vlan_enabled` / `radio` / etc. additions.

## Behavior change worth a look

`wlan_band` becomes `Optional`+`Computed` and **drops its `both` default**, because two `Optional` fields with a mutual `ConflictsWith` can't keep a default (the default would trip the conflict). Practically: a config that set neither field previously sent `wlan_band="both"`; now it leaves both unset and the controller's own default applies (read back into state). For configs that explicitly set `wlan_band`, nothing changes.

## The `wlan_band` omission (the tricky part)

The controller derives `wlan_bands` **from** a present `wlan_band` and ignores the array otherwise. Empirically:
- `wlan_band="5g"` + `wlan_bands=["5g","6g"]` → persisted `["5g"]`
- `wlan_band="both"` + `wlan_bands=["5g","6g"]` → persisted `["2g","5g"]` (`both` expands to 2.4 + 5 — not a permissive "defer to the array")

So when `wlan_bands` is configured, the update path **omits** `wlan_band` (its `omitempty` drops it from the JSON) and pins `setting_preference=manual`, matching the UniFi UI when bands are hand-picked. Whether `wlan_bands` is configured is gated on `d.GetRawConfig()` (not `d.Get`), so the `Computed` read-back of an unset array can't echo stale state over a deliberate `wlan_band` change.

## Validation

- `go build`, `go vet`, `gofmt` clean
- `ResourceWLAN().InternalValidate()` passes (confirms the `ConflictsWith`+`Computed` schema is legal)
- Acceptance test `TestAccWLAN_wlan_bands` added (mirrors `TestAccWLAN_wlan_band`)
- Running in production on a fork at `wlan_bands = ["5g", "6g"]` (5 + 6 GHz, no 2.4) against controller 10.x

## Docs

Intentionally omitted to match the recently-merged feature PRs (`#127` / `#130` etc. didn't touch `docs/`), since `docs/` is tfplugindocs-generated and regenerated separately — a partial regen here would also sweep in every other merged-but-undocumented attribute. Happy to add a regen if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SCDby9NWYT5gsEB6jYbt3
