### PR TITLE
fix(account): map RADIUS VLAN assignment via the vlan attribute (#95)

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -26,7 +26,8 @@ unifi_account data source can be used to retrieve RADIUS user accounts
 ### Read-Only
 
 - `id` (String) The ID of this account.
-- `network_id` (String) ID of the network for this account
+- `network_id` (String) The ID of the UniFi network configuration (the controller's `networkconf_id`) associated with this account. This is distinct from the `vlan` attribute, which is the 802.1Q VLAN ID delivered via RADIUS.
 - `password` (String, Sensitive) The password of the account.
 - `tunnel_medium_type` (Number) See RFC2868 section 3.2
 - `tunnel_type` (Number) See RFC2868 section 3.1
+- `vlan` (Number) The 802.1Q VLAN ID assigned to clients authenticating with this account via RADIUS dynamic VLAN assignment. `0` means no VLAN is assigned.

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -5,11 +5,11 @@ subcategory: ""
 description: |-
   The unifi_account resource manages RADIUS user accounts in the UniFi controller's built-in RADIUS server.
   This resource is used for:
-  WPA2/WPA3-Enterprise wireless authentication802.1X wired authenticationMAC-based device authenticationVLAN assignment through RADIUS attributes
+  WPA2/WPA3-Enterprise wireless authentication802.1X wired authenticationMAC-based device authenticationDynamic VLAN assignment through RADIUS attributes (see the vlan attribute)
   Important Notes:
   For MAC-based authentication:
   Use the device's MAC address as both username and passwordConvert MAC address to uppercase with no separators (e.g., '00:11:22:33:44:55' becomes '001122334455')VLAN Assignment:
-  If no VLAN is specified in the profile, clients will use the network's untagged VLANVLAN assignment uses standard RADIUS tunnel attributes
+  Set the vlan attribute to the 802.1Q VLAN ID the controller should assign to authenticated clientsVLAN assignment is delivered using the standard RADIUS tunnel attributes (tunnel_type/tunnel_medium_type)If no VLAN is specified, clients will use the network's untagged VLAN
   Limitations:
   MAC-based authentication works only for wireless and wired clientsL2TP remote access VPN is not supported with MAC authenticationAccounts must be unique within a site
 ---
@@ -22,15 +22,16 @@ This resource is used for:
   * WPA2/WPA3-Enterprise wireless authentication
   * 802.1X wired authentication
   * MAC-based device authentication
-  * VLAN assignment through RADIUS attributes
+  * Dynamic VLAN assignment through RADIUS attributes (see the `vlan` attribute)
 
 Important Notes:
 1. For MAC-based authentication:
    * Use the device's MAC address as both username and password
    * Convert MAC address to uppercase with no separators (e.g., '00:11:22:33:44:55' becomes '001122334455')
 2. VLAN Assignment:
-   * If no VLAN is specified in the profile, clients will use the network's untagged VLAN
-   * VLAN assignment uses standard RADIUS tunnel attributes
+   * Set the `vlan` attribute to the 802.1Q VLAN ID the controller should assign to authenticated clients
+   * VLAN assignment is delivered using the standard RADIUS tunnel attributes (`tunnel_type`/`tunnel_medium_type`)
+   * If no VLAN is specified, clients will use the network's untagged VLAN
 
 Limitations:
   * MAC-based authentication works only for wireless and wired clients
@@ -49,7 +50,7 @@ Limitations:
 
 ### Optional
 
-- `network_id` (String) The ID of the network (VLAN) to assign to clients authenticating with this account. This is used in conjunction with the tunnel attributes to provide VLAN assignment via RADIUS.
+- `network_id` (String) The ID of a UniFi network configuration (the controller's `networkconf_id`) to associate with this account. This is a reference to a network object and is distinct from the `vlan` attribute, which sets the 802.1Q VLAN ID delivered via RADIUS.
 - `site` (String) The name of the UniFi site where this RADIUS account should be created. If not specified, the default site will be used.
 - `tunnel_medium_type` (Number) The RADIUS tunnel medium type attribute ([RFC 2868](https://tools.ietf.org/html/rfc2868), section 3.2). Common values:
   * `6` - 802 (includes Ethernet, Token Ring, FDDI) (default)
@@ -63,6 +64,7 @@ Only change this if you need specific tunneling behavior. Defaults to `6`.
   * `9` - Point-to-Point Protocol (L2TP)
 
 Only change this if you need specific tunneling behavior. Defaults to `13`.
+- `vlan` (Number) The 802.1Q VLAN ID to assign to clients authenticating with this account, used for RADIUS dynamic VLAN assignment. It is delivered together with the tunnel attributes (`tunnel_type`/`tunnel_medium_type`). Omitting this attribute (or setting it to `0`) means no VLAN is assigned; if a VLAN was set out-of-band (e.g. in the controller UI), omitting it here removes it on the next apply.
 
 ### Read-Only
 

--- a/internal/provider/acctest/data_account_test.go
+++ b/internal/provider/acctest/data_account_test.go
@@ -2,10 +2,12 @@ package acctest
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	pt "github.com/filipowm/terraform-provider-unifi/internal/provider/testing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"testing"
 )
 
 func TestAccDataAccount_default(t *testing.T) {
@@ -35,6 +37,22 @@ func TestAccDataAccount_mac(t *testing.T) {
 	})
 }
 
+func TestAccDataAccount_vlan(t *testing.T) {
+	name := acctest.RandomWithPrefix("tfacc")
+	_, vlan := pt.GetTestVLAN(t)
+	AcceptanceTest(t, AcceptanceTestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAccountConfigVLAN(name, "secure_1234", vlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.unifi_account.test", "vlan", strconv.Itoa(vlan)),
+					resource.TestCheckResourceAttrPair("data.unifi_account.test", "vlan", "unifi_account.test", "vlan"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataAccountConfig(name, password string) string {
 	return fmt.Sprintf(`
 resource "unifi_account" "test" {
@@ -49,4 +67,21 @@ depends_on = [
   ]
 }
 `, name, password)
+}
+
+func testAccDataAccountConfigVLAN(name, password string, vlan int) string {
+	return fmt.Sprintf(`
+resource "unifi_account" "test" {
+	name = "%[1]s"
+	password = "%[2]s"
+	vlan = %[3]d
+}
+
+data "unifi_account" "test" {
+	name = "%[1]s"
+depends_on = [
+    unifi_account.test
+  ]
+}
+`, name, password, vlan)
 }

--- a/internal/provider/acctest/resource_account_test.go
+++ b/internal/provider/acctest/resource_account_test.go
@@ -2,8 +2,10 @@ package acctest
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	pt "github.com/filipowm/terraform-provider-unifi/internal/provider/testing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -45,6 +47,31 @@ func TestAccAccount_mac(t *testing.T) {
 	})
 }
 
+func TestAccAccount_vlan(t *testing.T) {
+	name := acctest.RandomWithPrefix("tfacc")
+	_, vlan := pt.GetTestVLAN(t)
+	_, vlan2 := pt.GetTestVLAN(t)
+	AcceptanceTest(t, AcceptanceTestCase{
+		// TODO: CheckDestroy: ,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountConfigVLAN(name, "secure", vlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_account.test", "name", name),
+					resource.TestCheckResourceAttr("unifi_account.test", "vlan", strconv.Itoa(vlan)),
+				),
+			},
+			{
+				Config: testAccAccountConfigVLAN(name, "secure", vlan2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_account.test", "vlan", strconv.Itoa(vlan2)),
+				),
+			},
+			pt.ImportStep("unifi_account.test"),
+		},
+	})
+}
+
 func testAccAccountConfig(name, password string) string {
 	return fmt.Sprintf(`
 resource "unifi_account" "test" {
@@ -52,4 +79,14 @@ resource "unifi_account" "test" {
 	password = "%[2]s"
 }
 `, name, password)
+}
+
+func testAccAccountConfigVLAN(name, password string, vlan int) string {
+	return fmt.Sprintf(`
+resource "unifi_account" "test" {
+	name = "%[1]s"
+	password = "%[2]s"
+	vlan = %[3]d
+}
+`, name, password, vlan)
 }

--- a/internal/provider/radius/data_account.go
+++ b/internal/provider/radius/data_account.go
@@ -49,9 +49,16 @@ func DataAccount() *schema.Resource {
 				Computed:    true,
 			},
 			"network_id": {
-				Description: "ID of the network for this account",
-				Type:        schema.TypeString,
-				Computed:    true,
+				Description: "The ID of the UniFi network configuration (the controller's `networkconf_id`) associated with this " +
+					"account. This is distinct from the `vlan` attribute, which is the 802.1Q VLAN ID delivered via RADIUS.",
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vlan": {
+				Description: "The 802.1Q VLAN ID assigned to clients authenticating with this account via RADIUS dynamic VLAN " +
+					"assignment. `0` means no VLAN is assigned.",
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 		},
 	}
@@ -78,6 +85,7 @@ func dataAccountRead(ctx context.Context, d *schema.ResourceData, meta interface
 			d.Set("tunnel_type", account.TunnelType)
 			d.Set("tunnel_medium_type", account.TunnelMediumType)
 			d.Set("network_id", account.NetworkID)
+			d.Set("vlan", account.VLAN)
 			d.Set("site", site)
 			return nil
 		}

--- a/internal/provider/radius/resource_account.go
+++ b/internal/provider/radius/resource_account.go
@@ -18,14 +18,15 @@ func ResourceAccount() *schema.Resource {
 			"  * WPA2/WPA3-Enterprise wireless authentication\n" +
 			"  * 802.1X wired authentication\n" +
 			"  * MAC-based device authentication\n" +
-			"  * VLAN assignment through RADIUS attributes\n\n" +
+			"  * Dynamic VLAN assignment through RADIUS attributes (see the `vlan` attribute)\n\n" +
 			"Important Notes:\n" +
 			"1. For MAC-based authentication:\n" +
 			"   * Use the device's MAC address as both username and password\n" +
 			"   * Convert MAC address to uppercase with no separators (e.g., '00:11:22:33:44:55' becomes '001122334455')\n" +
 			"2. VLAN Assignment:\n" +
-			"   * If no VLAN is specified in the profile, clients will use the network's untagged VLAN\n" +
-			"   * VLAN assignment uses standard RADIUS tunnel attributes\n\n" +
+			"   * Set the `vlan` attribute to the 802.1Q VLAN ID the controller should assign to authenticated clients\n" +
+			"   * VLAN assignment is delivered using the standard RADIUS tunnel attributes (`tunnel_type`/`tunnel_medium_type`)\n" +
+			"   * If no VLAN is specified, clients will use the network's untagged VLAN\n\n" +
 			"Limitations:\n" +
 			"  * MAC-based authentication works only for wireless and wired clients\n" +
 			"  * L2TP remote access VPN is not supported with MAC authentication\n" +
@@ -88,10 +89,20 @@ func ResourceAccount() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 15),
 			},
 			"network_id": {
-				Description: "The ID of the network (VLAN) to assign to clients authenticating with this account. This is used in " +
-					"conjunction with the tunnel attributes to provide VLAN assignment via RADIUS.",
+				Description: "The ID of a UniFi network configuration (the controller's `networkconf_id`) to associate with this " +
+					"account. This is a reference to a network object and is distinct from the `vlan` attribute, which sets the " +
+					"802.1Q VLAN ID delivered via RADIUS.",
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"vlan": {
+				Description: "The 802.1Q VLAN ID to assign to clients authenticating with this account, used for RADIUS dynamic " +
+					"VLAN assignment. It is delivered together with the tunnel attributes (`tunnel_type`/`tunnel_medium_type`). " +
+					"Omitting this attribute (or setting it to `0`) means no VLAN is assigned; if a VLAN was set out-of-band " +
+					"(e.g. in the controller UI), omitting it here removes it on the next apply.",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(2),
 			},
 		},
 	}
@@ -190,6 +201,7 @@ func resourceAccountSetResourceData(resp *unifi.Account, d *schema.ResourceData,
 	d.Set("tunnel_type", resp.TunnelType)
 	d.Set("tunnel_medium_type", resp.TunnelMediumType)
 	d.Set("network_id", resp.NetworkID)
+	d.Set("vlan", resp.VLAN)
 	return nil
 }
 
@@ -200,5 +212,6 @@ func resourceAccountGetResourceData(d *schema.ResourceData) (*unifi.Account, err
 		TunnelType:       d.Get("tunnel_type").(int),
 		TunnelMediumType: d.Get("tunnel_medium_type").(int),
 		NetworkID:        d.Get("network_id").(string),
+		VLAN:             d.Get("vlan").(int),
 	}, nil
 }

--- a/internal/provider/radius/resource_account.go
+++ b/internal/provider/radius/resource_account.go
@@ -98,7 +98,7 @@ func ResourceAccount() *schema.Resource {
 			"vlan": {
 				Description: "The 802.1Q VLAN ID to assign to clients authenticating with this account, used for RADIUS dynamic " +
 					"VLAN assignment. It is delivered together with the tunnel attributes (`tunnel_type`/`tunnel_medium_type`). " +
-					"Omitting this attribute (or setting it to `0`) means no VLAN is assigned; if a VLAN was set out-of-band " +
+					"Omitting this attribute means no VLAN is assigned; if a VLAN was set out-of-band " +
 					"(e.g. in the controller UI), omitting it here removes it on the next apply.",
 				Type:         schema.TypeInt,
 				Optional:     true,

--- a/internal/provider/radius/resource_account_test.go
+++ b/internal/provider/radius/resource_account_test.go
@@ -1,0 +1,39 @@
+package radius
+
+import (
+	"testing"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestResourceAccountGetResourceData_mapsVLAN verifies that the `vlan` attribute is
+// mapped onto the go-unifi Account struct on the write path. Regression lock for #95.
+func TestResourceAccountGetResourceData_mapsVLAN(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceAccount().Schema, map[string]interface{}{
+		"name":     "tfacc",
+		"password": "secure",
+		"vlan":     90,
+	})
+
+	req, err := resourceAccountGetResourceData(d)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if req.VLAN != 90 {
+		t.Fatalf("expected Account.VLAN == 90, got %d", req.VLAN)
+	}
+}
+
+// TestResourceAccountSetResourceData_readsVLAN verifies that the controller-returned
+// VLAN is written back into state on the read path. Regression lock for #95.
+func TestResourceAccountSetResourceData_readsVLAN(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceAccount().Schema, map[string]interface{}{})
+
+	if diags := resourceAccountSetResourceData(&unifi.Account{Name: "x", VLAN: 90}, d, "default"); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if got := d.Get("vlan").(int); got != 90 {
+		t.Fatalf("expected vlan == 90 in state, got %d", got)
+	}
+}


### PR DESCRIPTION
Fixes #95

## Summary

The legacy SDKv2 `unifi_account` resource and data source had no way to assign a RADIUS user to a specific 802.1Q VLAN, even though the underlying go-unifi SDK (`unifi.Account.VLAN`) and the controller already support it. This adds an additive `vlan` attribute so RADIUS-authenticated users can be dynamically placed onto a VLAN, and clarifies the previously misleading descriptions that conflated the network config ID with the 802.1Q VLAN ID.

## Changes

- Added a new `vlan` attribute to the `unifi_account` resource (`TypeInt`, `Optional`, validated with `validation.IntAtLeast(2)`).
- Added a new `vlan` attribute to the `unifi_account` data source (`TypeInt`, `Computed`).
- Wired `vlan` to `unifi.Account.VLAN` at all three mapping touchpoints:
  - `resourceAccountGetResourceData` (write path) — `VLAN: d.Get("vlan").(int)`.
  - `resourceAccountSetResourceData` (resource read path) — `d.Set("vlan", resp.VLAN)`.
  - `dataAccountRead` (data-source read path) — `d.Set("vlan", account.VLAN)`.
- Revised the misleading resource description and the `network_id` descriptions (resource + data source) to distinguish `networkconf_id` from the 802.1Q `vlan`.
- Regenerated `docs/resources/account.md` and `docs/data-sources/account.md` via tfplugindocs.

No upstream work was needed: go-unifi v1.9.2 already exposes and (un)marshals `Account.VLAN` (`account.generated.go:36`). No provider registration change (the resource already lives in the legacy SDKv2 `provider.go`; it was not added to `provider_v2.go`).

## Backward compatibility

Not breaking. The `vlan` attribute is additive (`Optional` on the resource, `Computed` on the data source), so no state migration is required and existing configurations continue to plan/apply unchanged.

One behavior change worth noting for release/upgrade notes: because `vlan` is config-authoritative (plain `Optional` with an unconditional read-back, consistent with the existing `network_id` semantics), a TF-managed account whose VLAN was set out-of-band in the controller UI will, after upgrading, show drift and have that VLAN cleared on the next apply unless `vlan` is added to the configuration. Before this change the field was ignored entirely.

## Testing

- Unit (no Docker, package `radius`), in new `internal/provider/radius/resource_account_test.go`:
  - `TestResourceAccountGetResourceData_mapsVLAN` — write path maps `vlan: 90` to `Account.VLAN == 90`.
  - `TestResourceAccountSetResourceData_readsVLAN` — read path sets `vlan == 90` in state from a `unifi.Account`.
  - Both pass with the fix and fail without it.
- Acceptance (skipped without `TF_ACC=1`):
  - `acctest/resource_account_test.go` — `TestAccAccount_vlan` covers create-with-vlan, an update step changing the VLAN (X→Y), and `pt.ImportStep` to exercise read-path repopulation.
  - `acctest/data_account_test.go` — `TestAccDataAccount_vlan` asserts `TestCheckResourceAttr` and `TestCheckResourceAttrPair` on `vlan` between the data source and the resource.
- Acceptance tests were NOT run (they require a live UniFi controller / Docker). `go build ./...`, `go vet`, and the `radius` unit tests pass.
- No state-migration test (additive `Optional`/`Computed` attribute is backward compatible in SDKv2).
- No `examples/` added: `unifi_account` has no `examples/` directory in the repo (pre-existing gap) and the additive fix did not require one.

## Review

1 review round(s) run; both lead-developer and unifi-expert signed off (0 critical / 0 major).

## Notes / follow-ups

- Validator uses `IntAtLeast(2)`, deliberately excluding VLAN 1 (native/untagged) and omitting an upper bound. This aligns with go-unifi's (non-enforced) field regex and avoids colliding with the shared acceptance VLAN allocator (`vlanMax=4095`, monotonic). Residual edge case: clearly-invalid VLAN IDs (>4094) pass plan-time validation and could cause perpetual drift if the controller clamps them — documented tradeoff, unverified on a live 9.x controller.
- `TestAccAccount_vlan` is the first import round-trip for this resource. If a `make testacc` run shows a `password` mismatch on import (controller may not echo `x_password`), add `pt.ImportStep("unifi_account.test", "password")` to ignore the sensitive field.
- Minor nits left for later: `TODO: CheckDestroy:` placeholder on the new acceptance test, slightly inconsistent HCL indentation of the `depends_on` block in the data-source test config, and the optional addition of `examples/resources/unifi_account/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
