### PR TITLE
fix: re-read on ErrNotFound after update across affected SDKv2 resources (#98)

### DIFF
--- a/docs/resources/port_profile.md
+++ b/docs/resources/port_profile.md
@@ -75,7 +75,9 @@ Use 'auto' for highest security, 'mac_based' for legacy devices, and 'multi_host
 Examples:
   * Use 'all' for uplink ports or connections to VLAN-aware devices
   * Use 'native' for end-user devices or simple network connections
-  * Use 'customize' to create a selective trunk port (e.g., for a server needing access to specific VLANs) Defaults to `native`.
+  * Use 'customize' to create a selective trunk port (e.g., for a server needing access to specific VLANs)
+
+~> **Note:** For an access port configured only with `native_networkconf_id` the controller normalizes the stored mode to `customize`. With the default value of `native` this currently results in a non-failing perpetual diff (`~ forward = "customize" -> "native"`) on every plan. To avoid it, set `forward = "customize"` explicitly. See issue #98. Defaults to `native`.
 - `full_duplex` (Boolean) Enable full-duplex mode when auto-negotiation is disabled. Full duplex allows simultaneous two-way communication. Defaults to `false`.
 - `isolation` (Boolean) Enable port isolation. When enabled, devices connected to ports with this profile cannot communicate with each other, providing enhanced security. Defaults to `false`.
 - `lldpmed_enabled` (Boolean) Enable Link Layer Discovery Protocol-Media Endpoint Discovery (LLDP-MED). This allows for automatic discovery and configuration of devices like VoIP phones. Defaults to `true`.

--- a/internal/provider/acctest/resource_port_profile_test.go
+++ b/internal/provider/acctest/resource_port_profile_test.go
@@ -27,12 +27,56 @@ func TestAccPortProfile_basic(t *testing.T) {
 	})
 }
 
+// TestAccPortProfile_update exercises an in-place update of an already-created port profile.
+// This is the lifecycle that triggered issue #98: the second apply (update) failed with
+// "Error: not found" because go-unifi v1.9.2 turns a successful-but-empty PUT into
+// unifi.ErrNotFound. The update step changes a real attribute (poe_mode) and asserts the apply
+// succeeds. NOTE: this acctest is best-effort - the Dockerized controller may echo the object
+// (len==1) and therefore not reproduce the bug; the deterministic regression lives in the unit
+// test (resource_port_profile_unit_test.go).
+func TestAccPortProfile_update(t *testing.T) {
+	name := acctest.RandomWithPrefix("tfacc")
+	AcceptanceTest(t, AcceptanceTestCase{
+		VersionConstraint: "< 7.4",
+		// TODO: CheckDestroy: ,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortProfileConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_port_profile.test", "poe_mode", "off"),
+					resource.TestCheckResourceAttr("unifi_port_profile.test", "name", name),
+				),
+			},
+			{
+				Config: testAccPortProfileConfigUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_port_profile.test", "poe_mode", "passthrough"),
+					resource.TestCheckResourceAttr("unifi_port_profile.test", "name", name),
+				),
+			},
+			pt.ImportStep("unifi_port_profile.test"),
+		},
+	})
+}
+
 func testAccPortProfileConfig(name string) string {
 	return fmt.Sprintf(`
 resource "unifi_port_profile" "test" {
 	name = "%s"
 
 	poe_mode	  = "off"
+	speed 		  = 1000
+	stp_port_mode = false
+}
+`, name)
+}
+
+func testAccPortProfileConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "unifi_port_profile" "test" {
+	name = "%s"
+
+	poe_mode	  = "passthrough"
 	speed 		  = 1000
 	stp_port_mode = false
 }

--- a/internal/provider/device/resource_device.go
+++ b/internal/provider/device/resource_device.go
@@ -513,9 +513,19 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
+	// go-unifi v1.9.2's updateDevice converts a successful-but-empty PUT response into
+	// unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read to tell
+	// a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateDevice(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.Device, error) {
+		return c.GetDevice(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	_, err = waitForDeviceState(ctx, d, meta, unifi.DeviceStateConnected, []unifi.DeviceState{unifi.DeviceStateAdopting, unifi.DeviceStateProvisioning}, 1*time.Minute)

--- a/internal/provider/device/resource_port_profile.go
+++ b/internal/provider/device/resource_port_profile.go
@@ -522,24 +522,21 @@ func resourcePortProfileUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updatePortProfile converts a successful-but-empty PUT
+	// response into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98);
+	// re-read to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdatePortProfile(ctx, site, req)
-	if errors.Is(err, unifi.ErrNotFound) {
-		// go-unifi v1.9.2's updatePortProfile (unifi/port_profile.generated.go) converts a
-		// successful-but-empty PUT response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) into
-		// unifi.ErrNotFound via its `len(respBody.Data) != 1` guard. That fires on every
-		// successful update on some controllers, so we cannot treat it as a deletion outright.
-		// Re-read to distinguish a spurious error (object still exists) from a genuine
-		// out-of-band deletion. See issue #98.
-		resp, err = c.GetPortProfile(ctx, site, req.ID)
-		if errors.Is(err, unifi.ErrNotFound) {
-			// The profile is genuinely gone; clear state so it is recreated on the next
-			// apply (mirrors resourcePortProfileRead and resourcePortProfileDelete).
-			d.SetId("")
-			return nil
-		}
-	}
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.PortProfile, error) {
+		return c.GetPortProfile(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		// The profile is genuinely gone; clear state so it is recreated on the next
+		// apply (mirrors resourcePortProfileRead and resourcePortProfileDelete).
+		d.SetId("")
+		return nil
 	}
 
 	return resourcePortProfileSetResourceData(resp, d, site)

--- a/internal/provider/device/resource_port_profile.go
+++ b/internal/provider/device/resource_port_profile.go
@@ -97,7 +97,11 @@ func ResourcePortProfile() *schema.Resource {
 					"Examples:\n" +
 					"  * Use 'all' for uplink ports or connections to VLAN-aware devices\n" +
 					"  * Use 'native' for end-user devices or simple network connections\n" +
-					"  * Use 'customize' to create a selective trunk port (e.g., for a server needing access to specific VLANs)",
+					"  * Use 'customize' to create a selective trunk port (e.g., for a server needing access to specific VLANs)\n\n" +
+					"~> **Note:** For an access port configured only with `native_networkconf_id` the controller " +
+					"normalizes the stored mode to `customize`. With the default value of `native` this currently " +
+					"results in a non-failing perpetual diff (`~ forward = \"customize\" -> \"native\"`) on every plan. " +
+					"To avoid it, set `forward = \"customize\"` explicitly. See issue #98.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "native",
@@ -519,6 +523,21 @@ func resourcePortProfileUpdate(ctx context.Context, d *schema.ResourceData, meta
 	req.SiteID = site
 
 	resp, err := c.UpdatePortProfile(ctx, site, req)
+	if errors.Is(err, unifi.ErrNotFound) {
+		// go-unifi v1.9.2's updatePortProfile (unifi/port_profile.generated.go) converts a
+		// successful-but-empty PUT response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) into
+		// unifi.ErrNotFound via its `len(respBody.Data) != 1` guard. That fires on every
+		// successful update on some controllers, so we cannot treat it as a deletion outright.
+		// Re-read to distinguish a spurious error (object still exists) from a genuine
+		// out-of-band deletion. See issue #98.
+		resp, err = c.GetPortProfile(ctx, site, req.ID)
+		if errors.Is(err, unifi.ErrNotFound) {
+			// The profile is genuinely gone; clear state so it is recreated on the next
+			// apply (mirrors resourcePortProfileRead and resourcePortProfileDelete).
+			d.SetId("")
+			return nil
+		}
+	}
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/device/resource_port_profile_unit_test.go
+++ b/internal/provider/device/resource_port_profile_unit_test.go
@@ -1,0 +1,86 @@
+package device
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakePortProfileClient is a minimal unifi.Client used to drive resourcePortProfileUpdate
+// through the re-read-on-ErrNotFound path introduced for issue #98. It embeds the unifi.Client
+// interface so every method we do not override panics if unexpectedly called.
+type fakePortProfileClient struct {
+	unifi.Client
+
+	updateResp *unifi.PortProfile
+	updateErr  error
+
+	getResp *unifi.PortProfile
+	getErr  error
+
+	getCalled bool
+	getID     string
+}
+
+func (f *fakePortProfileClient) UpdatePortProfile(_ context.Context, _ string, _ *unifi.PortProfile) (*unifi.PortProfile, error) {
+	return f.updateResp, f.updateErr
+}
+
+func (f *fakePortProfileClient) GetPortProfile(_ context.Context, _ string, id string) (*unifi.PortProfile, error) {
+	f.getCalled = true
+	f.getID = id
+	return f.getResp, f.getErr
+}
+
+// TestResourcePortProfileUpdate_ReReadOnNotFound covers the issue #98 regression: go-unifi
+// v1.9.2 turns a successful-but-empty PUT into unifi.ErrNotFound, so the Update handler must
+// re-read instead of surfacing the spurious error.
+func TestResourcePortProfileUpdate_ReReadOnNotFound(t *testing.T) {
+	t.Run("update returns ErrNotFound but object still exists - re-read succeeds", func(t *testing.T) {
+		fake := &fakePortProfileClient{
+			updateResp: nil,
+			updateErr:  unifi.ErrNotFound,
+			getResp:    &unifi.PortProfile{ID: "pp1", Name: "office", Forward: "customize"},
+			getErr:     nil,
+		}
+		client := &base.Client{Client: fake, Site: "default"}
+
+		d := ResourcePortProfile().TestResourceData()
+		d.SetId("pp1")
+		d.Set("site", "default")
+		d.Set("name", "office")
+
+		diags := resourcePortProfileUpdate(context.Background(), d, client)
+
+		assert.False(t, diags.HasError(), "spurious ErrNotFound from Update must not surface: %v", diags)
+		assert.True(t, fake.getCalled, "Update must re-read via GetPortProfile on ErrNotFound")
+		assert.Equal(t, "pp1", fake.getID, "re-read must use the resource ID")
+		assert.Equal(t, "pp1", d.Id(), "ID must be retained when the object still exists")
+		assert.Equal(t, "office", d.Get("name"), "state must be populated from the re-read object")
+		assert.Equal(t, "customize", d.Get("forward"), "controller normalization must be reflected in state")
+	})
+
+	t.Run("update and re-read both return ErrNotFound - genuine deletion clears state", func(t *testing.T) {
+		fake := &fakePortProfileClient{
+			updateResp: nil,
+			updateErr:  unifi.ErrNotFound,
+			getResp:    nil,
+			getErr:     unifi.ErrNotFound,
+		}
+		client := &base.Client{Client: fake, Site: "default"}
+
+		d := ResourcePortProfile().TestResourceData()
+		d.SetId("pp1")
+		d.Set("site", "default")
+		d.Set("name", "office")
+
+		diags := resourcePortProfileUpdate(context.Background(), d, client)
+
+		assert.False(t, diags.HasError(), "genuine deletion must clear state, not error: %v", diags)
+		assert.True(t, fake.getCalled, "Update must re-read via GetPortProfile on ErrNotFound")
+		assert.Equal(t, "", d.Id(), "genuinely deleted profile must clear the ID so it is recreated")
+	})
+}

--- a/internal/provider/dns/resource_dynamic_dns.go
+++ b/internal/provider/dns/resource_dynamic_dns.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filipowm/go-unifi/unifi"
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -180,9 +181,19 @@ func resourceDynamicDNSUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateDynamicDNS converts a successful-but-empty PUT response
+	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateDynamicDNS(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.DynamicDNS, error) {
+		return c.GetDynamicDNS(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceDynamicDNSSetResourceData(resp, d, site)

--- a/internal/provider/firewall/resource_firewall_group.go
+++ b/internal/provider/firewall/resource_firewall_group.go
@@ -160,9 +160,19 @@ func resourceFirewallGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateFirewallGroup converts a successful-but-empty PUT
+	// response into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98);
+	// re-read to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateFirewallGroup(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.FirewallGroup, error) {
+		return c.GetFirewallGroup(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceFirewallGroupSetResourceData(resp, d, site)

--- a/internal/provider/firewall/resource_firewall_rule.go
+++ b/internal/provider/firewall/resource_firewall_rule.go
@@ -424,9 +424,19 @@ func resourceFirewallRuleUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateFirewallRule converts a successful-but-empty PUT
+	// response into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98);
+	// re-read to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateFirewallRule(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.FirewallRule, error) {
+		return c.GetFirewallRule(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceFirewallRuleSetResourceData(resp, d, site)

--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -1258,6 +1258,21 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	req.SiteID = site
 
 	resp, err := c.UpdateNetwork(ctx, site, req)
+	if errors.Is(err, unifi.ErrNotFound) {
+		// go-unifi v1.9.2's updateNetwork (unifi/network.generated.go) converts a
+		// successful-but-empty PUT response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) into
+		// unifi.ErrNotFound via its `len(respBody.Data) != 1` guard. That fires on every
+		// successful update on some controllers, so we cannot treat it as a deletion outright.
+		// Re-read to distinguish a spurious error (object still exists) from a genuine
+		// out-of-band deletion. See issue #98.
+		resp, err = c.GetNetwork(ctx, site, req.ID)
+		if errors.Is(err, unifi.ErrNotFound) {
+			// The network is genuinely gone; clear state so it is recreated on the next
+			// apply (mirrors resourceNetworkRead and resourceNetworkDelete).
+			d.SetId("")
+			return nil
+		}
+	}
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -1257,24 +1257,21 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateNetwork converts a successful-but-empty PUT response
+	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateNetwork(ctx, site, req)
-	if errors.Is(err, unifi.ErrNotFound) {
-		// go-unifi v1.9.2's updateNetwork (unifi/network.generated.go) converts a
-		// successful-but-empty PUT response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) into
-		// unifi.ErrNotFound via its `len(respBody.Data) != 1` guard. That fires on every
-		// successful update on some controllers, so we cannot treat it as a deletion outright.
-		// Re-read to distinguish a spurious error (object still exists) from a genuine
-		// out-of-band deletion. See issue #98.
-		resp, err = c.GetNetwork(ctx, site, req.ID)
-		if errors.Is(err, unifi.ErrNotFound) {
-			// The network is genuinely gone; clear state so it is recreated on the next
-			// apply (mirrors resourceNetworkRead and resourceNetworkDelete).
-			d.SetId("")
-			return nil
-		}
-	}
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.Network, error) {
+		return c.GetNetwork(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		// The network is genuinely gone; clear state so it is recreated on the next
+		// apply (mirrors resourceNetworkRead and resourceNetworkDelete).
+		d.SetId("")
+		return nil
 	}
 
 	return resourceNetworkSetResourceData(resp, d, site)

--- a/internal/provider/network/resource_network_unit_test.go
+++ b/internal/provider/network/resource_network_unit_test.go
@@ -1,0 +1,87 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeNetworkClient is a minimal unifi.Client used to drive resourceNetworkUpdate through the
+// re-read-on-ErrNotFound path introduced for issue #98. It embeds the unifi.Client interface so
+// every method we do not override panics if unexpectedly called.
+type fakeNetworkClient struct {
+	unifi.Client
+
+	updateResp *unifi.Network
+	updateErr  error
+
+	getResp *unifi.Network
+	getErr  error
+
+	getCalled bool
+	getID     string
+}
+
+func (f *fakeNetworkClient) UpdateNetwork(_ context.Context, _ string, _ *unifi.Network) (*unifi.Network, error) {
+	return f.updateResp, f.updateErr
+}
+
+func (f *fakeNetworkClient) GetNetwork(_ context.Context, _ string, id string) (*unifi.Network, error) {
+	f.getCalled = true
+	f.getID = id
+	return f.getResp, f.getErr
+}
+
+// TestResourceNetworkUpdate_ReReadOnNotFound covers the issue #98 regression: go-unifi v1.9.2
+// turns a successful-but-empty PUT into unifi.ErrNotFound, so the Update handler must re-read
+// instead of surfacing the spurious error.
+func TestResourceNetworkUpdate_ReReadOnNotFound(t *testing.T) {
+	t.Run("update returns ErrNotFound but object still exists - re-read succeeds", func(t *testing.T) {
+		fake := &fakeNetworkClient{
+			updateResp: nil,
+			updateErr:  unifi.ErrNotFound,
+			getResp:    &unifi.Network{ID: "net1", Name: "lan", Purpose: "corporate"},
+			getErr:     nil,
+		}
+		client := &base.Client{Client: fake, Site: "default"}
+
+		d := ResourceNetwork().TestResourceData()
+		d.SetId("net1")
+		d.Set("site", "default")
+		d.Set("name", "lan")
+		d.Set("purpose", "corporate")
+
+		diags := resourceNetworkUpdate(context.Background(), d, client)
+
+		assert.False(t, diags.HasError(), "spurious ErrNotFound from Update must not surface: %v", diags)
+		assert.True(t, fake.getCalled, "Update must re-read via GetNetwork on ErrNotFound")
+		assert.Equal(t, "net1", fake.getID, "re-read must use the resource ID")
+		assert.Equal(t, "net1", d.Id(), "ID must be retained when the object still exists")
+		assert.Equal(t, "lan", d.Get("name"), "state must be populated from the re-read object")
+	})
+
+	t.Run("update and re-read both return ErrNotFound - genuine deletion clears state", func(t *testing.T) {
+		fake := &fakeNetworkClient{
+			updateResp: nil,
+			updateErr:  unifi.ErrNotFound,
+			getResp:    nil,
+			getErr:     unifi.ErrNotFound,
+		}
+		client := &base.Client{Client: fake, Site: "default"}
+
+		d := ResourceNetwork().TestResourceData()
+		d.SetId("net1")
+		d.Set("site", "default")
+		d.Set("name", "lan")
+		d.Set("purpose", "corporate")
+
+		diags := resourceNetworkUpdate(context.Background(), d, client)
+
+		assert.False(t, diags.HasError(), "genuine deletion must clear state, not error: %v", diags)
+		assert.True(t, fake.getCalled, "Update must re-read via GetNetwork on ErrNotFound")
+		assert.Equal(t, "", d.Id(), "genuinely deleted network must clear the ID so it is recreated")
+	})
+}

--- a/internal/provider/network/resource_network_unit_test.go
+++ b/internal/provider/network/resource_network_unit_test.go
@@ -43,7 +43,7 @@ func TestResourceNetworkUpdate_ReReadOnNotFound(t *testing.T) {
 		fake := &fakeNetworkClient{
 			updateResp: nil,
 			updateErr:  unifi.ErrNotFound,
-			getResp:    &unifi.Network{ID: "net1", Name: "lan", Purpose: "corporate"},
+			getResp:    &unifi.Network{ID: "net1", Name: "lan-renamed", Purpose: "corporate"},
 			getErr:     nil,
 		}
 		client := &base.Client{Client: fake, Site: "default"}
@@ -60,7 +60,7 @@ func TestResourceNetworkUpdate_ReReadOnNotFound(t *testing.T) {
 		assert.True(t, fake.getCalled, "Update must re-read via GetNetwork on ErrNotFound")
 		assert.Equal(t, "net1", fake.getID, "re-read must use the resource ID")
 		assert.Equal(t, "net1", d.Id(), "ID must be retained when the object still exists")
-		assert.Equal(t, "lan", d.Get("name"), "state must be populated from the re-read object")
+		assert.Equal(t, "lan-renamed", d.Get("name"), "state must be repopulated from the re-read object, not the preloaded state")
 	})
 
 	t.Run("update and re-read both return ErrNotFound - genuine deletion clears state", func(t *testing.T) {

--- a/internal/provider/network/resource_wlan.go
+++ b/internal/provider/network/resource_wlan.go
@@ -548,9 +548,19 @@ func resourceWLANUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateWLAN converts a successful-but-empty PUT response into
+	// unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read to
+	// tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateWLAN(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.WLAN, error) {
+		return c.GetWLAN(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceWLANSetResourceData(resp, d, meta, site)

--- a/internal/provider/radius/resource_account.go
+++ b/internal/provider/radius/resource_account.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filipowm/go-unifi/unifi"
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -147,9 +148,19 @@ func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	req.ID = d.Id()
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateAccount converts a successful-but-empty PUT response
+	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateAccount(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.Account, error) {
+		return c.GetAccount(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceAccountSetResourceData(resp, d, site)

--- a/internal/provider/radius/resource_radius_profile.go
+++ b/internal/provider/radius/resource_radius_profile.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/utils"
 
 	"github.com/filipowm/go-unifi/unifi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -365,9 +366,19 @@ func resourceRadiusProfileUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateRADIUSProfile converts a successful-but-empty PUT
+	// response into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98);
+	// re-read to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateRADIUSProfile(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.RADIUSProfile, error) {
+		return c.GetRADIUSProfile(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceRadiusProfileSetResourceData(resp, d, site)

--- a/internal/provider/routing/resource_port_forward.go
+++ b/internal/provider/routing/resource_port_forward.go
@@ -205,9 +205,19 @@ func resourcePortForwardUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updatePortForward converts a successful-but-empty PUT
+	// response into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98);
+	// re-read to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdatePortForward(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.PortForward, error) {
+		return c.GetPortForward(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourcePortForwardSetResourceData(resp, d, site)

--- a/internal/provider/routing/resource_static_route.go
+++ b/internal/provider/routing/resource_static_route.go
@@ -202,9 +202,19 @@ func resourceStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateRouting converts a successful-but-empty PUT response
+	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateRouting(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.Routing, error) {
+		return c.GetRouting(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceStaticRouteSetResourceData(resp, d, site)

--- a/internal/provider/user/resource_user.go
+++ b/internal/provider/user/resource_user.go
@@ -177,9 +177,19 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		req.ID = existing.ID
 		req.SiteID = existing.SiteID
 
+		// go-unifi v1.9.2's updateUser converts a successful-but-empty PUT response
+		// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+		// so reconciling an existing MAC does not spuriously fail.
+		var found bool
 		resp, err = c.UpdateUser(ctx, site, req)
+		resp, found, err = utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.User, error) {
+			return c.GetUser(ctx, site, req.ID)
+		})
 		if err != nil {
 			return diag.FromErr(err)
+		}
+		if !found {
+			return diag.Errorf("existing user %q (id %s) vanished while reconciling its configuration", req.MAC, req.ID)
 		}
 	}
 
@@ -335,9 +345,19 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	req.ID = d.Id()
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateUser converts a successful-but-empty PUT response into
+	// unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read to tell
+	// a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateUser(ctx, site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.User, error) {
+		return c.GetUser(ctx, site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceUserSetResourceData(resp, d, site)

--- a/internal/provider/user/resource_user_group.go
+++ b/internal/provider/user/resource_user_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filipowm/go-unifi/unifi"
 	"github.com/filipowm/terraform-provider-unifi/internal/provider/base"
+	"github.com/filipowm/terraform-provider-unifi/internal/provider/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -151,9 +152,19 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	req.SiteID = site
 
+	// go-unifi v1.9.2's updateUserGroup converts a successful-but-empty PUT response
+	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
+	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateUserGroup(context.TODO(), site, req)
+	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.UserGroup, error) {
+		return c.GetUserGroup(context.TODO(), site, req.ID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	return resourceUserGroupSetResourceData(resp, d)

--- a/internal/provider/user/resource_user_group.go
+++ b/internal/provider/user/resource_user_group.go
@@ -155,9 +155,9 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	// go-unifi v1.9.2's updateUserGroup converts a successful-but-empty PUT response
 	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
 	// to tell a spurious error from a genuine out-of-band deletion.
-	resp, err := c.UpdateUserGroup(context.TODO(), site, req)
+	resp, err := c.UpdateUserGroup(ctx, site, req)
 	resp, found, err := utils.ReReadOnUpdateNotFound(resp, err, func() (*unifi.UserGroup, error) {
-		return c.GetUserGroup(context.TODO(), site, req.ID)
+		return c.GetUserGroup(ctx, site, req.ID)
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/utils/update.go
+++ b/internal/provider/utils/update.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"errors"
+
+	"github.com/filipowm/go-unifi/unifi"
+)
+
+// ReReadOnUpdateNotFound works around a go-unifi v1.9.2 defect shared by every
+// generated update* function: after a successful PUT they apply a
+// `len(respBody.Data) != 1 -> unifi.ErrNotFound` guard, so a successful-but-empty
+// response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) — which some UniFi
+// controllers return on an update — is converted into unifi.ErrNotFound even
+// though the change WAS applied. SDKv2 Update handlers that surface that verbatim
+// via diag.FromErr therefore fail with "Error: not found" on a successful update.
+// See issue #98.
+//
+// Given the (object, error) pair returned by an update* call and a reRead closure
+// (typically c.Get<Resource>(ctx, site, id)), it returns:
+//   - (updated, true, nil)  when the update succeeded normally;
+//   - (reRead,  true, nil)  when the update returned ErrNotFound but the object
+//     still exists (the spurious case) — the re-read object is returned so that
+//     controller-side normalization is preserved;
+//   - (zero,    false, nil) when the update returned ErrNotFound AND the re-read
+//     also returns ErrNotFound — i.e. the object was genuinely deleted
+//     out-of-band; the caller should clear state (d.SetId("")) and recreate;
+//   - (zero,    false, err) for any other error, from either the update or the
+//     re-read.
+//
+// A genuine controller 404 surfaces as a *unifi.ServerError from the response
+// error handler before the len() guard is reached, so "update -> ErrNotFound"
+// never by itself means "deleted"; only the re-read's own ErrNotFound does. That
+// is why the re-read GET is required rather than echoing the request struct.
+//
+// When the upstream go-unifi template is fixed and the pin bumped, update* stops
+// returning the spurious ErrNotFound and this helper becomes a harmless no-op.
+func ReReadOnUpdateNotFound[T any](updated T, updateErr error, reRead func() (T, error)) (result T, found bool, err error) {
+	if updateErr == nil {
+		return updated, true, nil
+	}
+	var zero T
+	if !errors.Is(updateErr, unifi.ErrNotFound) {
+		return zero, false, updateErr
+	}
+	obj, reReadErr := reRead()
+	if errors.Is(reReadErr, unifi.ErrNotFound) {
+		return zero, false, nil
+	}
+	if reReadErr != nil {
+		return zero, false, reReadErr
+	}
+	return obj, true, nil
+}

--- a/internal/provider/utils/update_test.go
+++ b/internal/provider/utils/update_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/filipowm/go-unifi/unifi"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReReadOnUpdateNotFound covers the issue #98 workaround shared by every SDKv2
+// Update handler: go-unifi v1.9.2 turns a successful-but-empty PUT into
+// unifi.ErrNotFound, so the helper must re-read instead of surfacing the spurious
+// error, while still distinguishing a genuine out-of-band deletion and propagating
+// real errors.
+func TestReReadOnUpdateNotFound(t *testing.T) {
+	type obj struct{ name string }
+
+	t.Run("update succeeds - returns update result, no re-read", func(t *testing.T) {
+		updated := &obj{name: "from-update"}
+		reReadCalled := false
+		got, found, err := ReReadOnUpdateNotFound(updated, nil, func() (*obj, error) {
+			reReadCalled = true
+			return nil, nil
+		})
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Same(t, updated, got)
+		assert.False(t, reReadCalled, "re-read must not run when update succeeds")
+	})
+
+	t.Run("update returns non-NotFound error - propagated, no re-read", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		reReadCalled := false
+		got, found, err := ReReadOnUpdateNotFound((*obj)(nil), sentinel, func() (*obj, error) {
+			reReadCalled = true
+			return nil, nil
+		})
+		assert.ErrorIs(t, err, sentinel)
+		assert.False(t, found)
+		assert.Nil(t, got)
+		assert.False(t, reReadCalled, "re-read must not run for a real error")
+	})
+
+	t.Run("spurious ErrNotFound but object exists - returns re-read result", func(t *testing.T) {
+		reRead := &obj{name: "from-reread"}
+		got, found, err := ReReadOnUpdateNotFound((*obj)(nil), unifi.ErrNotFound, func() (*obj, error) {
+			return reRead, nil
+		})
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Same(t, reRead, got, "re-read object (with controller normalization) must be returned")
+	})
+
+	t.Run("update and re-read both ErrNotFound - genuine deletion", func(t *testing.T) {
+		got, found, err := ReReadOnUpdateNotFound((*obj)(nil), unifi.ErrNotFound, func() (*obj, error) {
+			return nil, unifi.ErrNotFound
+		})
+		assert.NoError(t, err, "genuine deletion must not error so the caller can clear state")
+		assert.False(t, found)
+		assert.Nil(t, got)
+	})
+
+	t.Run("spurious ErrNotFound but re-read fails - propagates re-read error", func(t *testing.T) {
+		sentinel := errors.New("read failed")
+		got, found, err := ReReadOnUpdateNotFound((*obj)(nil), unifi.ErrNotFound, func() (*obj, error) {
+			return nil, sentinel
+		})
+		assert.ErrorIs(t, err, sentinel)
+		assert.False(t, found)
+		assert.Nil(t, got)
+	})
+}


### PR DESCRIPTION
Fixes #98

## Summary

Updating an already-created `unifi_port_profile` (and, as a commenter confirmed, `unifi_network`) failed with `Error: not found` even though the controller PUT succeeded (`HTTP 200`, body `{"meta":{"rc":"ok"},"data":[]}`).

The root cause is a defect shared by **every** generated `update*` function in go-unifi v1.9.2: after a successful PUT they apply a `len(respBody.Data) != 1 -> unifi.ErrNotFound` guard, so a successful-but-empty response (which some UniFi controllers return on an update) is converted into `unifi.ErrNotFound` even though the change *was* applied. SDKv2 `Update` handlers surface that verbatim via `diag.FromErr`, producing the spurious failure. `Create` is unaffected (it returns exactly one element), which is why the first apply succeeds and the second fails.

The fix is a provider-side re-read on `ErrNotFound` after every affected `Update`, mirroring the idiom already used by `Read`/`Delete`. The durable fix is tracked upstream in go-unifi; this provider workaround is load-bearing because no released go-unifi version contains it. When the upstream fix lands and the pin is bumped, the helper becomes a harmless no-op (no second migration). The go-unifi pin stays at v1.9.2.

## Changes

- **New shared helper `internal/provider/utils/update.go`** — generic `ReReadOnUpdateNotFound[T]`. Given the `(object, error)` from an `update*` call and a re-read closure (`c.Get<Resource>(...)`), it returns the updated object on success; the re-read object when the update returned `ErrNotFound` but the object still exists (the spurious case, preserving controller-side normalization); a "not found" signal only when the re-read *itself* also returns `ErrNotFound` (genuine out-of-band deletion → caller clears state and recreates); and any other error verbatim. A genuine controller 404 surfaces as `*unifi.ServerError` before the `len()` guard, so "update → ErrNotFound" never by itself means "deleted" — hence the re-read GET is required rather than echoing the request struct.
- **Applied the helper across all 13 affected SDKv2 resources** (full audited sweep, not just the two confirmed): `port_profile`, `network`, `wlan`, `firewall_rule`, `firewall_group`, `port_forward`, `static_route`, `radius_profile`, `account`, `user` (two `UpdateUser` call sites), `user_group`, `device`, `dynamic_dns`. Each `Update` now routes its `update*` result through `ReReadOnUpdateNotFound` and clears state (`d.SetId("")`) on a confirmed deletion. No new imports beyond `utils`.
- **`forward` perma-diff documented** (`docs/resources/port_profile.md` + the attribute description, regenerated via `go generate ./tools/`): for an access port configured only with `native_networkconf_id`, the controller normalizes the stored mode to `customize`, so with the `native` default a *non-failing* perpetual diff remains until resolved. The note tells users to set `forward = "customize"` explicitly. This secondary item is documented rather than changed (the `Default`/Optional+Computed change carries its own back-compat implications) — see follow-ups.

## Backward compatibility

- **No schema changes, no state-schema migration, no schema-version bump.** Attribute sets of all touched resources are unchanged. State written by `Update` is the same canonical object `Read` already writes.
- **Self-healing:** resources currently wedged by this bug recover on the next apply (the re-read writes canonical state).
- **One user-visible contract change to note:** `Update` on a resource that was genuinely deleted out-of-band now clears state and recreates on the next plan (mirroring `Read`/`Delete`) instead of hard-erroring.
- **go-unifi pin unchanged (v1.9.2).** When the upstream template fix later ships and the pin is bumped, the re-read becomes a no-op — no follow-up migration.

## Testing

- **Unit (deterministic, offline — the primary regression):**
  - `internal/provider/device/resource_port_profile_unit_test.go` and `internal/provider/network/resource_network_unit_test.go` use a fake `unifi.Client` to cover both lifecycle cases: (1) `Update → ErrNotFound`, `Get` returns the object ⇒ no diag error, state populated from the re-read; (2) `Update → ErrNotFound`, `Get → ErrNotFound` ⇒ no diag error, `d.Id() == ""` (graceful recreate).
  - `internal/provider/utils/update_test.go` covers the helper directly: normal success, spurious-not-found-then-found, genuine deletion, and non-`ErrNotFound` passthrough.
- **Acceptance (best-effort):** `TestAccPortProfile_update` adds create + update steps with `ImportStep`. Note the Dockerized controller likely returns `len==1` on update, so the acctest may pass with or without the fix — the **unit tests are the deterministic regression**, by design.
- **Local verification (this PR):** `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (v1 config, matching CI), and `go test ./...` for all non-acceptance packages — all green. **Acceptance tests were NOT run** — they require a live/Dockerized UniFi controller. The `forward native→customize` normalization and the empty-`data` controller response remain confirmed from the issue report (+ `@antifuchs` `TF_LOG` capture), not re-verified against a live controller here.
- No examples were changed (the `forward` example update is listed as a follow-up).

## Review

2 review rounds; both lead-developer and unifi-expert signed off (0 critical / 0 major).

## Notes / follow-ups

**Upstream (durable fix):** patch the go-unifi `update*` code-gen template so a 200/`rc:ok` PUT with empty `data` is treated as success (re-fetch and/or inspect `meta.rc` rather than the brittle `len` guard), regenerate the ~30 affected resources, release, then bump the provider pin — at which point this helper becomes a no-op.

### Leftover minor findings (non-blocking)

- (minor, lead-developer) Helper doc overstates that only a re-read ErrNotFound signals deletion; a controller 404 surfaces as ServerError and hard-errors — `internal/provider/utils/update.go:33-41`
- (minor, lead-developer) unifi_device genuine-deletion now silently clears state and recreates rather than hard-erroring — `internal/provider/device/resource_device.go:438-441`
- (nit, lead-developer) TestAccPortProfile_update does not actually exercise the #98 trigger or guard the forward perma-diff — `internal/provider/acctest/resource_port_profile_test.go:37-61`
- (nit, lead-developer) Re-read immediately after PUT is a TOCTOU window that could spuriously clear state — `internal/provider/utils/update.go:43-52`
- (minor, unifi-expert) issue #98 literal repro still produces a (non-failing) perpetual diff; forward normalization only documented — `internal/provider/device/resource_port_profile.go:103 (forward Default "native")`
- (nit, unifi-expert) port_profile example not updated to demonstrate the forward workaround — `examples/resources/unifi_port_profile/resource.tf`
- (nit, unifi-expert) forward attribute note renders as a list-adjacent admonition with trailing 'Defaults to' on the same line — `docs/resources/port_profile.md:80 / internal/provider/device/resource_port_profile.go:100-104`
