### PR TITLE
fix(network): preserve IPv6/DHCPv6 values on import (#96)

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -145,8 +145,12 @@ Default is true for easier management. Defaults to `true`.
 Typically longer than IPv4 DHCP leases. Defaults to `86400`.
 - `dhcp_v6_start` (String) The starting IPv6 address for the DHCPv6 range. Used in static DHCPv6 configuration.
 Must be a valid IPv6 address within your allocated IPv6 subnet.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; turn DHCPv6 off with `dhcp_v6_enabled`/`ipv6_interface_type` instead. Set it explicitly to manage the value from Terraform.
 - `dhcp_v6_stop` (String) The ending IPv6 address for the DHCPv6 range. Used in static DHCPv6 configuration.
 Must be after dhcp_v6_start in the IPv6 address space.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; turn DHCPv6 off with `dhcp_v6_enabled`/`ipv6_interface_type` instead. Set it explicitly to manage the value from Terraform.
 - `dhcpd_boot_enabled` (Boolean) Enables DHCP boot options for PXE boot or network boot configurations. When enabled:
 * Allows network devices to boot from a TFTP server
 * Requires dhcpd_boot_server and dhcpd_boot_filename to be set
@@ -197,6 +201,8 @@ Choose based on your IPv6 deployment strategy and ISP capabilities. Defaults to 
 * `wan` - Primary WAN interface
 * `wan2` - Secondary WAN interface
 Only applicable when `ipv6_interface_type` is 'pd'.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.
 - `ipv6_pd_prefixid` (String) The IPv6 Prefix ID for Prefix Delegation. Used to:
 * Differentiate multiple delegated prefixes
 * Create unique subnets from the delegated prefix
@@ -204,9 +210,13 @@ Typically a hexadecimal value (e.g., '0', '1', 'a1').
 - `ipv6_pd_start` (String) The starting IPv6 address for Prefix Delegation range.
 Only used when `ipv6_interface_type` is 'pd'.
 Must be within the delegated prefix range.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.
 - `ipv6_pd_stop` (String) The ending IPv6 address for Prefix Delegation range.
 Only used when `ipv6_interface_type` is 'pd'.
 Must be after `ipv6_pd_start` within the delegated prefix.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.
 - `ipv6_ra_enable` (Boolean) Enables IPv6 Router Advertisements (RA). When enabled:
 * Announces IPv6 prefix information to clients
 * Enables SLAAC address configuration
@@ -220,6 +230,8 @@ Must be after `ipv6_pd_start` within the delegated prefix.
 * `medium` - Standard priority
 * `low` - For backup or secondary networks
 Affects router selection when multiple IPv6 routers exist.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; turn Router Advertisements off with `ipv6_ra_enable` instead. Set it explicitly to manage the value from Terraform.
 - `ipv6_ra_valid_lifetime` (Number) The valid lifetime (in seconds) for IPv6 addresses in Router Advertisements.
 * Must be greater than or equal to `ipv6_ra_preferred_lifetime`
 * Default: 86400 (24 hours)
@@ -227,6 +239,8 @@ Affects router selection when multiple IPv6 routers exist.
 - `ipv6_static_subnet` (String) The static IPv6 subnet in CIDR notation (e.g., '2001:db8::/64') when using static IPv6.
 Only applicable when `ipv6_interface_type` is 'static'.
 Must be a valid IPv6 subnet allocated to your organization.
+
+This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the current value reported by the controller, so a value configured in the UI (or read in via `terraform import`) is preserved rather than planned for removal. Note the standard `Optional`+`Computed` "sticky value" semantics — once the controller has a value, removing the attribute from configuration leaves that value in place rather than clearing it (the provider serializes this field with `omitempty`, so an empty value is never sent). There is therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` away from 'static' to disable static IPv6 instead. Set it explicitly to manage the value from Terraform.
 - `multicast_dns` (Boolean) Enables Multicast DNS (mDNS/Bonjour/Avahi) on the network. When enabled:
 * Allows device discovery (e.g., printers, Chromecasts)
 * Supports zero-configuration networking

--- a/internal/provider/acctest/resource_network_test.go
+++ b/internal/provider/acctest/resource_network_test.go
@@ -185,6 +185,81 @@ func TestAccNetwork_v6(t *testing.T) {
 	})
 }
 
+// TestAccNetwork_v6ImportPreserved is the regression test for issue #96: after
+// importing a network whose IPv6/DHCPv6 value fields are set on the controller, a
+// subsequent apply of a config that omits those fields must be a clean no-op rather
+// than a perpetual `value -> null` diff.
+//
+// Pre-fix those five fields were Optional-but-not-Computed, so a sparse config planned
+// them to null; go-unifi's `,omitempty` tags then dropped the empty strings from the
+// PUT so the controller never cleared them, and the identical diff reappeared on every
+// plan (never converging). The fix makes them Optional+Computed so an omitted field
+// inherits the controller's value.
+//
+// Uses *static* IPv6 (not Prefix Delegation): the Dockerized controller cannot provide
+// an upstream-delegated prefix, which is why the broader TestAccNetwork_v6 is skipped.
+// Consequently dhcp_v6_start/stop and ipv6_ra_priority ARE exercised here, while the
+// pd-only fields (ipv6_pd_start/stop, ipv6_pd_interface) are covered by the identical
+// Optional+Computed mechanism + the offline schema guard
+// (network.TestResourceNetwork_ipv6FieldsOptionalComputed) + code review, not by CI.
+func TestAccNetwork_v6ImportPreserved(t *testing.T) {
+	name := acctest.RandomWithPrefix("tfacc")
+	subnet, vlan := pt.GetTestVLAN(t)
+
+	AcceptanceTest(t, AcceptanceTestCase{
+		// TODO: CheckDestroy: ,
+		Steps: []resource.TestStep{
+			// 1. Create a network with static IPv6, static DHCPv6 and an explicit RA
+			// priority all set, so the controller holds non-empty values for every
+			// field under test.
+			{
+				Config: testAccNetworkConfigV6ImportPreserved(name, subnet, vlan, "foo.local", true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_interface_type", "static"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_static_subnet", "fd6a:37be:e364::1/64"),
+					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_start", "fd6a:37be:e364::2"),
+					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_stop", "fd6a:37be:e364::7d1"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_ra_priority", "high"),
+				),
+			},
+			// 2. Import by name, exactly like the reporter's `terraform import ... name=...`.
+			{
+				ResourceName:      "unifi_network.test",
+				ImportState:       true,
+				ImportStateId:     "name=" + name,
+				ImportStateVerify: true,
+			},
+			// 3. Decisive #96 guard: re-apply a config that OMITS the IPv6/DHCPv6 value
+			// fields while changing an unrelated attribute (domain_name) so a real
+			// Update fires. The previously-set values must be preserved
+			// (Optional+Computed), not planned to null. The harness's automatic
+			// post-apply empty-plan check is the discriminator: pre-fix this step fails
+			// because the `-> null` diff persists; post-fix it passes.
+			{
+				Config:           testAccNetworkConfigV6ImportPreserved(name, subnet, vlan, "bar.local", false),
+				ConfigPlanChecks: pt.CheckResourceActions("unifi_network.test", plancheck.ResourceActionUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_network.test", "domain_name", "bar.local"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_static_subnet", "fd6a:37be:e364::1/64"),
+					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_start", "fd6a:37be:e364::2"),
+					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_stop", "fd6a:37be:e364::7d1"),
+					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_ra_priority", "high"),
+				),
+			},
+			// 4. Convergence proof: re-applying the identical sparse config must be a
+			// no-op. This step FAILS pre-fix (the perpetual `-> null` diff) and PASSES
+			// post-fix — the artifact that proves #96 is actually closed, not merely
+			// de-crashed.
+			{
+				Config: testAccNetworkConfigV6ImportPreserved(name, subnet, vlan, "bar.local", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
 func TestAccNetwork_wan(t *testing.T) {
 	name := acctest.RandomWithPrefix("tfacc")
 
@@ -787,6 +862,48 @@ resource "unifi_network" "test" {
 	dhcp_v6_lease = 12 * 60 * 60
 }
 `, name, subnet, vlan, gatewayIP, dhcpdV6Start, dhcpdV6Stop, strings.Join(quoteStrings(dhcpV6DNS), ","))
+}
+
+// testAccNetworkConfigV6ImportPreserved renders a corporate network with static IPv6,
+// static DHCPv6 and an explicit RA priority (issue #96). When includeV6Values is false
+// the IPv6/DHCPv6 *value* fields (ipv6_static_subnet, dhcp_v6_start/stop,
+// ipv6_ra_priority) are omitted while the IPv6 *gating* fields (ipv6_interface_type,
+// dhcp_v6_enabled, ipv6_ra_enable) are kept — reproducing the sparse post-import config
+// from the report. The IPv4 DHCP control fields are pinned in both variants so they
+// match the controller's stored values and cannot false-fail the convergence
+// (ExpectEmptyPlan) step.
+func testAccNetworkConfigV6ImportPreserved(name string, subnet *net.IPNet, vlan int, domainName string, includeV6Values bool) string {
+	v6Values := ""
+	if includeV6Values {
+		v6Values = `
+	ipv6_static_subnet = "fd6a:37be:e364::1/64"
+	dhcp_v6_start      = "fd6a:37be:e364::2"
+	dhcp_v6_stop       = "fd6a:37be:e364::7d1"
+	ipv6_ra_priority   = "high"`
+	}
+	return fmt.Sprintf(`
+locals {
+	subnet  = "%[2]s"
+	vlan_id = %[3]d
+}
+
+resource "unifi_network" "test" {
+	name    = "%[1]s"
+	purpose = "corporate"
+
+	subnet       = local.subnet
+	vlan_id      = local.vlan_id
+	dhcp_start   = cidrhost(local.subnet, 6)
+	dhcp_stop    = cidrhost(local.subnet, 254)
+	dhcp_enabled = true
+	domain_name  = "%[4]s"
+
+	ipv6_interface_type = "static"
+	ipv6_ra_enable      = true
+	dhcp_v6_enabled     = true
+%[5]s
+}
+`, name, subnet, vlan, domainName, v6Values)
 }
 
 func testAccNetworkConfigMDNS(name string, subnet *net.IPNet, vlan int, mdns bool) string {

--- a/internal/provider/acctest/resource_network_test.go
+++ b/internal/provider/acctest/resource_network_test.go
@@ -196,12 +196,29 @@ func TestAccNetwork_v6(t *testing.T) {
 // plan (never converging). The fix makes them Optional+Computed so an omitted field
 // inherits the controller's value.
 //
-// Uses *static* IPv6 (not Prefix Delegation): the Dockerized controller cannot provide
-// an upstream-delegated prefix, which is why the broader TestAccNetwork_v6 is skipped.
-// Consequently dhcp_v6_start/stop and ipv6_ra_priority ARE exercised here, while the
-// pd-only fields (ipv6_pd_start/stop, ipv6_pd_interface) are covered by the identical
-// Optional+Computed mechanism + the offline schema guard
-// (network.TestResourceNetwork_ipv6FieldsOptionalComputed) + code review, not by CI.
+// Scope — this test uses *static* IPv6, not Prefix Delegation, because the PD value
+// fields (ipv6_pd_start/stop, ipv6_pd_interface) cannot be exercised on the Dockerized
+// controller: it has no upstream-delegated prefix to draw from. Those PD-only fields are
+// therefore covered by the identical Optional+Computed mechanism plus the offline schema
+// guard (network.TestResourceNetwork_ipv6FieldsOptionalComputed) and code review, not by
+// CI. The static-mode fields dhcp_v6_start/stop and ipv6_ra_priority ARE exercised here.
+//
+// This is NOT why the sibling TestAccNetwork_v6 (above) is skipped — do not conflate the
+// two. TestAccNetwork_v6 also uses static IPv6 (ipv6_interface_type="static" via
+// testAccNetworkConfigV6 / the static testAccNetworkConfigDhcpV6 helper), so its skip has
+// nothing to do with Prefix Delegation. It was `t.Skip("FIXME")`'d by an upstream commit
+// (paultyng#462, "Update supported versions", 2024-11) with no recorded reason. Because
+// this test reuses the same static dhcp_v6 schema path, if that undocumented FIXME turns
+// out to be a static-DHCPv6 round-trip problem on the Dockerized controller, this test
+// could inherit the same failure.
+//
+// CI-verifiability caveat: acceptance tests need a live controller (~20m) and are not run
+// in the change-authoring environment, so the static dhcp_v6 round-trip here is UNVERIFIED
+// against the Dockerized controller at the time of writing — do not assume the static path
+// is known-good. Before relying on this as the behavioral proof of the #96 fix, run
+// `make testacc TESTARGS='-run TestAccNetwork_v6ImportPreserved'` against Docker and record
+// the green result in the PR. Until then the offline schema guard above is the only
+// Docker-free regression net for the fix.
 func TestAccNetwork_v6ImportPreserved(t *testing.T) {
 	name := acctest.RandomWithPrefix("tfacc")
 	subnet, vlan := pt.GetTestVLAN(t)

--- a/internal/provider/acctest/resource_network_test.go
+++ b/internal/provider/acctest/resource_network_test.go
@@ -220,6 +220,10 @@ func TestAccNetwork_v6ImportPreserved(t *testing.T) {
 					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_start", "fd6a:37be:e364::2"),
 					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_stop", "fd6a:37be:e364::7d1"),
 					resource.TestCheckResourceAttr("unifi_network.test", "ipv6_ra_priority", "high"),
+					// Confirm the controller honored the pinned confounders; if it overrides
+					// either, the later ExpectEmptyPlan would fail confusingly — surface it here.
+					resource.TestCheckResourceAttr("unifi_network.test", "igmp_snooping", "false"),
+					resource.TestCheckResourceAttr("unifi_network.test", "dhcp_v6_dns_auto", "true"),
 				),
 			},
 			// 2. Import by name, exactly like the reporter's `terraform import ... name=...`.
@@ -869,9 +873,18 @@ resource "unifi_network" "test" {
 // the IPv6/DHCPv6 *value* fields (ipv6_static_subnet, dhcp_v6_start/stop,
 // ipv6_ra_priority) are omitted while the IPv6 *gating* fields (ipv6_interface_type,
 // dhcp_v6_enabled, ipv6_ra_enable) are kept — reproducing the sparse post-import config
-// from the report. The IPv4 DHCP control fields are pinned in both variants so they
-// match the controller's stored values and cannot false-fail the convergence
-// (ExpectEmptyPlan) step.
+// from the report.
+//
+// Every Optional-not-Computed, controller-populated confounder is pinned identically in
+// both variants so the ONLY attributes that vary between them are domain_name and the
+// value fields under test — otherwise the step-4 ExpectEmptyPlan could false-fail on an
+// unrelated field whose stored controller value differs from the (zero) value a sparse
+// config sends:
+//   - igmp_snooping: no schema Default and no go-unifi `,omitempty`, so it is always
+//     serialized; pin it to false so it cannot drift the convergence plan.
+//   - dhcp_v6_dns_auto: no go-unifi `,omitempty` (always serialized); pin it to its
+//     schema default (true) so enabling DHCPv6 here does not require a manual dhcp_v6_dns
+//     list — auto-off without a DNS list can be rejected by the controller at create.
 func testAccNetworkConfigV6ImportPreserved(name string, subnet *net.IPNet, vlan int, domainName string, includeV6Values bool) string {
 	v6Values := ""
 	if includeV6Values {
@@ -891,16 +904,18 @@ resource "unifi_network" "test" {
 	name    = "%[1]s"
 	purpose = "corporate"
 
-	subnet       = local.subnet
-	vlan_id      = local.vlan_id
-	dhcp_start   = cidrhost(local.subnet, 6)
-	dhcp_stop    = cidrhost(local.subnet, 254)
-	dhcp_enabled = true
-	domain_name  = "%[4]s"
+	subnet        = local.subnet
+	vlan_id       = local.vlan_id
+	dhcp_start    = cidrhost(local.subnet, 6)
+	dhcp_stop     = cidrhost(local.subnet, 254)
+	dhcp_enabled  = true
+	domain_name   = "%[4]s"
+	igmp_snooping = false
 
 	ipv6_interface_type = "static"
 	ipv6_ra_enable      = true
 	dhcp_v6_enabled     = true
+	dhcp_v6_dns_auto    = true
 %[5]s
 }
 `, name, subnet, vlan, domainName, v6Values)

--- a/internal/provider/network/resource_network.go
+++ b/internal/provider/network/resource_network.go
@@ -288,16 +288,34 @@ func ResourceNetwork() *schema.Resource {
 			},
 			"dhcp_v6_start": {
 				Description: "The starting IPv6 address for the DHCPv6 range. Used in static DHCPv6 configuration.\n" +
-					"Must be a valid IPv6 address within your allocated IPv6 subnet.",
+					"Must be a valid IPv6 address within your allocated IPv6 subnet.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; turn DHCPv6 off with " +
+					"`dhcp_v6_enabled`/`ipv6_interface_type` instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IsIPv6Address,
 			},
 			"dhcp_v6_stop": {
 				Description: "The ending IPv6 address for the DHCPv6 range. Used in static DHCPv6 configuration.\n" +
-					"Must be after dhcp_v6_start in the IPv6 address space.",
+					"Must be after dhcp_v6_start in the IPv6 address space.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; turn DHCPv6 off with " +
+					"`dhcp_v6_enabled`/`ipv6_interface_type` instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IsIPv6Address,
 			},
 			"domain_name": {
@@ -385,17 +403,35 @@ func ResourceNetwork() *schema.Resource {
 			"ipv6_static_subnet": {
 				Description: "The static IPv6 subnet in CIDR notation (e.g., '2001:db8::/64') when using static IPv6.\n" +
 					"Only applicable when `ipv6_interface_type` is 'static'.\n" +
-					"Must be a valid IPv6 subnet allocated to your organization.",
+					"Must be a valid IPv6 subnet allocated to your organization.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` " +
+					"away from 'static' to disable static IPv6 instead. Set it explicitly to manage the value from Terraform.",
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ipv6_pd_interface": {
 				Description: "The WAN interface to use for IPv6 Prefix Delegation. Options:\n" +
 					"* `wan` - Primary WAN interface\n" +
 					"* `wan2` - Secondary WAN interface\n" +
-					"Only applicable when `ipv6_interface_type` is 'pd'.",
+					"Only applicable when `ipv6_interface_type` is 'pd'.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` " +
+					"away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateWANV6NetworkGroup,
 			},
 			"ipv6_pd_prefixid": {
@@ -409,17 +445,35 @@ func ResourceNetwork() *schema.Resource {
 			"ipv6_pd_start": {
 				Description: "The starting IPv6 address for Prefix Delegation range.\n" +
 					"Only used when `ipv6_interface_type` is 'pd'.\n" +
-					"Must be within the delegated prefix range.",
+					"Must be within the delegated prefix range.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` " +
+					"away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IsIPv6Address,
 			},
 			"ipv6_pd_stop": {
 				Description: "The ending IPv6 address for Prefix Delegation range.\n" +
 					"Only used when `ipv6_interface_type` is 'pd'.\n" +
-					"Must be after `ipv6_pd_start` within the delegated prefix.",
+					"Must be after `ipv6_pd_start` within the delegated prefix.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; switch `ipv6_interface_type` " +
+					"away from 'pd' to disable Prefix Delegation instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IsIPv6Address,
 			},
 			"ipv6_ra_enable": {
@@ -462,9 +516,18 @@ func ResourceNetwork() *schema.Resource {
 					"* `high` - Preferred for primary networks\n" +
 					"* `medium` - Standard priority\n" +
 					"* `low` - For backup or secondary networks\n" +
-					"Affects router selection when multiple IPv6 routers exist.",
+					"Affects router selection when multiple IPv6 routers exist.\n\n" +
+					"This attribute is `Optional` + `Computed`: when omitted from configuration it inherits the " +
+					"current value reported by the controller, so a value configured in the UI (or read in via " +
+					"`terraform import`) is preserved rather than planned for removal. Note the standard " +
+					"`Optional`+`Computed` \"sticky value\" semantics — once the controller has a value, removing " +
+					"the attribute from configuration leaves that value in place rather than clearing it (the " +
+					"provider serializes this field with `omitempty`, so an empty value is never sent). There is " +
+					"therefore no way to clear it by deleting it from configuration; turn Router Advertisements " +
+					"off with `ipv6_ra_enable` instead. Set it explicitly to manage the value from Terraform.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateIpV6RAPriority,
 			},
 			"ipv6_ra_valid_lifetime": {
@@ -1257,7 +1320,7 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	req.SiteID = site
 
-	// go-unifi v1.9.2's updateNetwork converts a successful-but-empty PUT response
+	// go-unifi v1.9.3's updateNetwork converts a successful-but-empty PUT response
 	// into unifi.ErrNotFound (see utils.ReReadOnUpdateNotFound / issue #98); re-read
 	// to tell a spurious error from a genuine out-of-band deletion.
 	resp, err := c.UpdateNetwork(ctx, site, req)

--- a/internal/provider/network/resource_network_unit_test.go
+++ b/internal/provider/network/resource_network_unit_test.go
@@ -35,7 +35,7 @@ func (f *fakeNetworkClient) GetNetwork(_ context.Context, _ string, id string) (
 	return f.getResp, f.getErr
 }
 
-// TestResourceNetworkUpdate_ReReadOnNotFound covers the issue #98 regression: go-unifi v1.9.2
+// TestResourceNetworkUpdate_ReReadOnNotFound covers the issue #98 regression: go-unifi v1.9.3
 // turns a successful-but-empty PUT into unifi.ErrNotFound, so the Update handler must re-read
 // instead of surfacing the spurious error.
 func TestResourceNetworkUpdate_ReReadOnNotFound(t *testing.T) {
@@ -84,4 +84,44 @@ func TestResourceNetworkUpdate_ReReadOnNotFound(t *testing.T) {
 		assert.True(t, fake.getCalled, "Update must re-read via GetNetwork on ErrNotFound")
 		assert.Equal(t, "", d.Id(), "genuinely deleted network must clear the ID so it is recreated")
 	})
+}
+
+// TestResourceNetwork_ipv6FieldsOptionalComputed is the offline guard for issue #96.
+// The IPv6/DHCPv6 value fields whose go-unifi struct tags carry `,omitempty` must be
+// Optional+Computed so a sparse post-import config inherits the controller's value
+// instead of planning it to null (a diff the controller can never apply, producing a
+// perpetual post-import diff). This Docker-free test catches accidental removal of the
+// `Computed:` flag even when the acceptance coverage is skipped.
+func TestResourceNetwork_ipv6FieldsOptionalComputed(t *testing.T) {
+	s := ResourceNetwork().Schema
+
+	// These five reported fields plus the two same-class siblings carry `,omitempty`
+	// in the go-unifi Network struct, so they must round-trip via Optional+Computed.
+	computed := []string{
+		"dhcp_v6_start",
+		"dhcp_v6_stop",
+		"ipv6_pd_start",
+		"ipv6_pd_stop",
+		"ipv6_ra_priority",
+		"ipv6_static_subnet",
+		"ipv6_pd_interface",
+	}
+	for _, name := range computed {
+		attr, ok := s[name]
+		assert.True(t, ok, "schema must define %q", name)
+		if !ok {
+			continue
+		}
+		assert.True(t, attr.Optional, "%q must remain Optional", name)
+		assert.True(t, attr.Computed, "%q must be Computed so a sparse post-import config inherits the controller value (issue #96)", name)
+		// Computed + Default is rejected by SDKv2 at init; these must stay Default-free.
+		assert.Nil(t, attr.Default, "%q must not declare a Default (illegal with Computed)", name)
+	}
+
+	// ipv6_pd_prefixid is deliberately EXCLUDED: its go-unifi tag has no `,omitempty`,
+	// so an empty config value IS sent and clears it. Making it Computed would silently
+	// remove that working clear-by-omit behavior — a real BC break. Guard against it.
+	if attr, ok := s["ipv6_pd_prefixid"]; ok {
+		assert.False(t, attr.Computed, "ipv6_pd_prefixid must stay Optional-only: it has no go-unifi omitempty tag, so making it Computed would break clear-by-omit (issue #96)")
+	}
 }

--- a/internal/provider/utils/update.go
+++ b/internal/provider/utils/update.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filipowm/go-unifi/unifi"
 )
 
-// ReReadOnUpdateNotFound works around a go-unifi v1.9.2 defect shared by every
+// ReReadOnUpdateNotFound works around a go-unifi v1.9.3 defect shared by every
 // generated update* function: after a successful PUT they apply a
 // `len(respBody.Data) != 1 -> unifi.ErrNotFound` guard, so a successful-but-empty
 // response (HTTP 200, {"meta":{"rc":"ok"},"data":[]}) — which some UniFi


### PR DESCRIPTION
Fixes #96

## Summary

Importing a `unifi_network` whose IPv6/DHCPv6 value fields are set on the controller, then applying a config that omits those fields, produced a perpetual `value -> null` plan that never converged: the fields were `Optional` (not `Computed`), so a sparse config planned them to empty, but go-unifi serializes them with `,omitempty` so the empty value was never sent to the controller — the stored value stayed, and the identical diff reappeared on every plan.

This promotes exactly the IPv6/DHCPv6 string fields that carry `,omitempty` in go-unifi v1.9.3 from `Optional` to `Optional`+`Computed`, so an omitted field inherits the controller's current value instead of planning it to null. This is the idiomatic SDKv2 fix for post-import "sticky value" fields.

## Changes

- `internal/provider/network/resource_network.go`: added `Computed: true` to the 7 IPv6/DHCPv6 string fields whose go-unifi struct tags carry `,omitempty` — `dhcp_v6_start`, `dhcp_v6_stop`, `ipv6_static_subnet`, `ipv6_pd_interface`, `ipv6_pd_start`, `ipv6_pd_stop`, `ipv6_ra_priority`. Each field's description documents the resulting `Optional`+`Computed` "sticky value" semantics (omitting no longer clears; disable via the relevant gating field instead).
- **Deliberately NOT changed:** `ipv6_pd_prefixid` — its go-unifi tag has **no** `,omitempty`, so an empty config value **is** sent and clears it. Making it `Computed` would silently break that working clear-by-omit behavior (a real BC regression), so it stays `Optional`-only. A unit test locks this in.
- `docs/resources/network.md`: regenerated via `go generate -tags tools ./tools/` (schema-description driven; unrelated tfplugindocs drift not included).
- Incidental: corrected three stale `go-unifi v1.9.2` code comments to `v1.9.3` (the pinned version) in `resource_network.go`, `resource_network_unit_test.go`, and `utils/update.go`. Comment-only, no behavior change.

## Backward compatibility

Fully backward compatible. `Optional` -> `Optional`+`Computed` is additive: the stored type is unchanged (`TypeString`), so **no state migration and no `SchemaVersion` bump** are required; existing state and configs that set these fields are unaffected. The only behavior change is the intended one — omitting a previously-set field now preserves it rather than emitting a non-applyable `-> null` diff (which, due to `omitempty`, never actually cleared the value anyway). `ipv6_pd_prefixid` is intentionally excluded to preserve its clear-by-omit behavior.

## Testing

- Unit (offline, `internal/provider/network/resource_network_unit_test.go`): `TestResourceNetwork_ipv6FieldsOptionalComputed` — asserts the 7 fields are `Optional`+`Computed` and `Default`-free (Computed+Default is illegal in SDKv2), and that `ipv6_pd_prefixid` stays `Computed:false`. This is the Docker-free regression net for the fix. Passes.
- Acceptance (TF_ACC, written, **NOT run** — requires a live/Dockerized UniFi controller, ~20m): `TestAccNetwork_v6ImportPreserved` — create with static IPv6 + static DHCPv6 + explicit RA priority set -> import by name -> re-apply a sparse config that omits the value fields (changing `domain_name` to force a real Update) -> re-apply identical sparse config with `ExpectEmptyPlan()`. The empty-plan step is the discriminator: it fails pre-fix (perpetual `-> null`) and passes post-fix. Confounders (`igmp_snooping`, `dhcp_v6_dns_auto`) are pinned so the empty-plan check can't false-fail on an unrelated field. Uses static IPv6 (not Prefix Delegation) because the Dockerized controller has no upstream-delegated prefix; the PD value fields share the identical `Optional`+`Computed` mechanism and are covered by the offline schema guard + review.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean. (`golangci-lint`: the repo's `.golangci.yaml` is v1-format and the locally installed binary is v2.12.2, which cannot load it — a pre-existing env/config mismatch identical on `main`, not introduced here.)

## Review

Two full adversarial review rounds were run by `lead-developer` and `unifi-expert` (r1: 2 blocking, r2: 1 blocking — all resolved in commits `23b4907` "pin confounders" and `0d4bba8` "skip rationale"). The automated round-3 re-review and finalize step were interrupted by an API monthly-spend-limit, so a final independent gate was completed by hand (reviewer did not write the code): the full diff was re-reviewed and build/vet/gofmt/unit re-run green — **0 critical, 0 major**. The core fix was verified against go-unifi v1.9.3 (`omitempty` tags at `unifi/network.generated.go`).

## Notes / follow-ups

- Run `make testacc TESTARGS='-run TestAccNetwork_v6ImportPreserved'` against the Dockerized controller before release to empirically confirm the static-DHCPv6 round-trip (the sibling `TestAccNetwork_v6` is `t.Skip("FIXME")`'d upstream for an unrecorded reason; if that turns out to be a static-DHCPv6 issue, this test could inherit it).
- The new acceptance test has no `CheckDestroy` (matches the existing `resource_network_test.go` convention, which uses `// TODO: CheckDestroy:` throughout) — a suite-wide follow-up, not specific to this change.
- The per-field "sticky value" description paragraph is intentionally repeated across the 7 fields for Registry clarity; could be factored to a shared const later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
